### PR TITLE
Add option to disable use of steam://forceinputappid

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -265,6 +265,7 @@ struct sk_config_t
     bool        filter_stat_callback  = false;
     bool        spoof_BLoggedOn       = false;
     bool        auto_inject           =  true;  // Control implicit steam_api.dll bootstrapping
+    bool        skip_forceinputappid  = false;  // If true, steam://forceinputappid is not used.
 
     struct screenshot_handler_s {
       bool      enable_hook           =  true;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -421,6 +421,7 @@ struct {
     sk::ParameterBool*    force_load              = nullptr;
     sk::ParameterBool*    auto_inject             = nullptr;
     sk::ParameterStringW* dll_path                = nullptr;
+    sk::ParameterBool*    skip_forceinputappid    = nullptr;
   } system;
 
   struct {
@@ -1459,6 +1460,9 @@ auto DeclKeybind =
                                                          L" application start",                                        dll_ini,         L"Steam.Social",          L"OnlineStatus"),
     ConfigEntry (steam.system.dll_path,                  L"Path to a known-working SteamAPI dll for this game.",       dll_ini,         L"Steam.System",          L"SteamPipeDLL"),
     ConfigEntry (steam.callbacks.throttle,               L"-1=Unlimited, 0-oo=Upper bound limit to SteamAPI rate",     dll_ini,         L"Steam.System",          L"CallbackThrottle"),
+    ConfigEntry (steam.system.skip_forceinputappid,      L"If true, SpecialK will not invoke the "
+                                                         L"`steam://forceinputappid` endpoint.",                       dll_ini,         L"Steam.System",          L"SkipForceInputAppID"),
+
 
     // This option is per-game, since it has potential compatibility issues...
     ConfigEntry (steam.screenshots.smart_capture,        L"Enhanced screenshot speed and HUD options; D3D11-only.",    dll_ini,         L"Steam.Screenshots",     L"EnableSmartCapture"),
@@ -3734,6 +3738,7 @@ auto DeclKeybind =
   steam.system.early_overlay->load            (config.steam.preload_overlay);
   steam.system.force_load->load               (config.steam.force_load_steamapi);
   steam.system.auto_inject->load              (config.steam.auto_inject);
+  steam.system.skip_forceinputappid->load     (config.steam.skip_forceinputappid);
 
   int                                 throttle = -1;
   if (steam.callbacks.throttle->load (throttle))

--- a/src/steam/steam_api.cpp
+++ b/src/steam/steam_api.cpp
@@ -5203,6 +5203,30 @@ SK_Steam_ForceInputAppId (AppId64_t appid)
 {
   static volatile LONG changes = 0;
 
+  if ( config.steam.skip_forceinputappid )
+  {
+      // For some people who use Steam Input, SpecialK's invocation of
+      // the `steam://forceinputappid` endpoint causes at least two
+      // strange behaviors:
+      //   1. The directional inputs from a controller no longer have any
+      //      effect on the Steam Overlay; and
+      //   2. After a game closes, directional inputs from a controller no
+      //      longer have any effect in Steam's Big Picture Mode.
+      //
+      // It's not clear what the root cause of these issues is (or why only
+      // directional inputs are affected), but refraining from using the
+      // `steam://forceinputappid` endpoint appears to fix the problems.
+      //
+      // This solution may have other side effects relating to SpecialK's
+      // interactions with Steam Input, but some people may find the tradeoff
+      // to be worthwhile, particularly if they play video games from a couch
+      // where being able to use directional inputs to navigate the Steam
+      // Overlay and Steam's Big Picture Mode is an essential feature.
+      steam_log->Log( L"Skipped use of `steam://forceinputappid` endpoint "
+                      L"because Steam.System.SkipForceInputAppID is true." );
+      return;
+  }
+
   if ( ReadAcquire (&__SK_DLL_Ending) &&
        ReadAcquire (&changes) > 1 ) // First change is always to 0
   {


### PR DESCRIPTION
This changelist adds a new config option `Steam.System.SkipForceInputAppID`. If this option is set to `true`, SpecialK will not invoke Steam's `forceinputappid` endpoint. The default is `false`.

Setting this option to `true` resolves a problem that I have been experiencing in SpecialK for quite some time whereby, after SpecialK is injected into a game, gamepad directional inputs do not work on the Steam Overlay then and, after exiting the game, gamepad directional inputs do not work in Steam's Big Picture Mode either. This problem is very inconvenient for people who don't have a keyboard and mouse near where they play video games (e.g., a couch in a living room).

I am not the only one who has experienced this problem. Other people with the problem can be regularly found on the SpecialK discord. Here's one example from today: https://discord.com/channels/778539700981071872/778887425275199548/949667906902437949

I've tested this change and it works for me, although of course I can't guarantee it will address all situations where this was an issue.