### PR TITLE
Fix exception by removing no-op AC Valhalla code

### DIFF
--- a/src/plugins/ac_valhalla.cpp
+++ b/src/plugins/ac_valhalla.cpp
@@ -33,14 +33,4 @@
 
 void
 SK_ACV_InitPlugin (void)
-{
-//SK_SetPluginName (ACVD_VERSION_STR);
-
-  auto intro_vids =
-    SK_GetDLLConfig ()->get_section (L"ACValhalla.PlugIn").
-                        get_value   (L"DisableIntroVideos");
-
-  if (SK_IsTrue (intro_vids.c_str ()))
-  {
-  }
-}
+{ }


### PR DESCRIPTION
When using local injection with d3d11.dll, the call to `SK_GetDLLConfig` raises
an exception. It turns out that the AC Valhalla code is a no-op anyway, so I
just deleted the contents of `SK_ACV_InitPlugin`. I left the plugin itself in
the code in case we decide to re-implement its functionality at a later date.