### PR TITLE
Added CD PROJEKT RED's launchers to the blacklist

### DIFF
--- a/include/SpecialK/injection/blacklist.h
+++ b/include/SpecialK/injection/blacklist.h
@@ -131,6 +131,9 @@ static constexpr UNICODE_STRING __blacklist [] = {
   SK_MakeUnicode (L"ffx&x-2_launcher.exe"),
   SK_MakeUnicode (L"ubisoftgamelauncher.exe"),
   SK_MakeUnicode (L"uplayinstaller.exe"),
+  
+  SK_MakeUnicode (L"redprelauncher.exe"), // CD PROJEKT RED's pre-launcher included in the root of Cyberpunk 2077
+  SK_MakeUnicode (L"redlauncher.exe"),    // CD PROJEKT RED's launcher located below %APPDATA%
 
   SK_MakeUnicode (L"akibauu_config.exe"),
   SK_MakeUnicode (L"gameserver.exe"),// Sacred   game server
@@ -262,6 +265,9 @@ static constexpr UNICODE_STRING __blacklist [] = {
   SK_MakeUnicode (L"ffx&x-2_launcher.exe"),
   SK_MakeUnicode (L"ubisoftgamelauncher.exe"),
   SK_MakeUnicode (L"uplayinstaller.exe"),
+  
+  SK_MakeUnicode (L"redprelauncher.exe"), // CD PROJEKT RED's pre-launcher included in the root of Cyberpunk 2077
+  SK_MakeUnicode (L"redlauncher.exe"),    // CD PROJEKT RED's launcher located below %APPDATA%
 
   SK_MakeUnicode (L"akibauu_config.exe"),
   SK_MakeUnicode (L"gameserver.exe"),// Sacred   game server


### PR DESCRIPTION
When launching Cyberpunk 2077 on Steam, it launches `<path-to-game>\REDprelauncher.exe` which then launches `%LOCALAPPDATA%\Programs\CD Project Red\REDlauncher\REDlauncher.exe` which is the actual pre-game launcher for the game.

If the player then hits `Play` within the launcher, `<path-to-game>\bin\x64\Cyberpunk2077.exe` is launched, which is the game itself.