### PR TITLE
[Hatsune Miku: Project DIVA Mega Mix+] Addresses for the 1.02 game version.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2378,9 +2378,10 @@ auto DeclKeybind =
         config.window.always_on_top              =     0;
 
         // Now we patch the damn broken Windows 10 Version Check
-        //
+        // 1.01: 0x2C3201, File Location: 0x2C2801
+        // 1.02: 0x2C3681, File Location: 0x2C26D0
         auto win_ver_check_addr =
-          ((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x2c37b1);////0x2c3201); // File Location: 0x2c2801
+          ((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x2C3681);
         auto win_ver_check_pattern = "\x48\x8B\xCF";
 
         DWORD dwOrigProt =                                     PAGE_EXECUTE_READ;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2378,7 +2378,8 @@ auto DeclKeybind =
         config.window.always_on_top              =     0;
 
         // Now we patch the damn broken Windows 10 Version Check
-        // 1.01: 0x2C3201, File Location: 0x2C2801
+        // 1.00: 0x2C3201
+        // 1.01: 0x2C37B1, File Location: 0x2C2801
         // 1.02: 0x2C3681, File Location: 0x2C26D0
         auto win_ver_check_addr =
           ((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x2C3681);

--- a/src/plugins/unclassified.cpp
+++ b/src/plugins/unclassified.cpp
@@ -1279,11 +1279,18 @@ SK_HatsuneMiku_BeginFrame (void)
 
   extern float __target_fps;
 
+  // 1.00: 0x14B2A78
+  // 1.01: 0x14ACA68
+  // 1.02: 0x14ABBB8
   static uint32_t* puiGameLimit =
-        (uint32_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x14ACA68);//0x14B2A78);
+        (uint32_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x14ABBB8);
 
-  static auto menu_flag_addr = // Pointer at DivaMegaMix.exe+114EFF8h, Offset=780h
-      *(uintptr_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x1148fc8/*114EFF8*/) + 0x780;
+  // Pointer at DivaMegaMix.exe+, Offset=780h
+  // 1.00: 0x114EFF8
+  // 1.01: 0x1148FC8
+  // 1.02: 0x11481E8
+  static auto menu_flag_addr =
+      *(uintptr_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x11481E8) + 0x780;
 
   // Menu is Active, 60 FPS (or lower) framerate cap is required
   if ((*(uint8_t *)menu_flag_addr) & 0x1)


### PR DESCRIPTION
Updated addresses for the 1.02 game version.

In my tests everything seems to be ok. I compared the addresses with version 1.01 of the game on IDA. I left some comments with the old addresses.

Fixes #13.