### PR TITLE
Added separation between swapchain mgnt sections

### DIFF
--- a/src/control_panel/cfg_d3d11.cpp
+++ b/src/control_panel/cfg_d3d11.cpp
@@ -661,8 +661,19 @@ SK::ControlPanel::D3D11::Draw (void)
       }
 
       ImGui::EndGroup   ();
+
       ImGui::SameLine   ();
+      ImGui::ItemSize   (ImVec2(50.0f, 0.0f));
+      ImGui::SameLine   ();
+      
+      ImGui::VerticalSeparator ();
+
+      ImGui::SameLine   ();
+      ImGui::ItemSize   (ImVec2(50.0f, 0.0f));
+      ImGui::SameLine   ();
+
       ImGui::BeginGroup ();
+      ImGui::PushItemWidth (100.0f);
 
       ImGui::InputInt ("Presentation Interval",       &config.render.framerate.present_interval);
 
@@ -736,6 +747,7 @@ SK::ControlPanel::D3D11::Draw (void)
           }
         }
       }
+      ImGui::PopItemWidth ();
       ImGui::EndGroup ();
 
       const bool changed =


### PR DESCRIPTION
This adds some much needed separation between the two sections in SwapChain Management which would resolve user confusion.

![image](https://user-images.githubusercontent.com/10578344/187051807-d2ac10b4-6754-40f4-bcb9-e51dcc300ef8.png)
