### PR TITLE
Use ImGuiCol_WindowBg instead of boosting alpha

### DIFF
--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5394,6 +5394,16 @@ SK_ImGui_StageNextFrame (void)
   auto& io =
     ImGui::GetIO ();
 
+  ImGuiStyle& style =
+    ImGui::GetStyle();
+
+  static float orgWindowBg = style.Colors[ImGuiCol_WindowBg].w;
+
+  if (config.imgui.render.disable_alpha)
+    style.Colors[ImGuiCol_WindowBg].w = 1.0f;
+  else
+    style.Colors[ImGuiCol_WindowBg].w = orgWindowBg;
+
   ///SK_ComQIPtr <IDXGISwapChain> pSwapChain (rb.swapchain);
   ///
   ///if (pSwapChain != nullptr)

--- a/src/imgui/backends/imgui_d3d11.cpp
+++ b/src/imgui/backends/imgui_d3d11.cpp
@@ -355,7 +355,7 @@ ImGui_ImplDX11_RenderDrawData (ImDrawData* draw_data)
     const ImDrawList* cmd_list =
       draw_data->CmdLists [n];
 
-    if (config.imgui.render.disable_alpha)
+    if (config.imgui.render.disable_alpha && false)
     {
       for (INT i = 0; i < cmd_list->VtxBuffer.Size; i++)
       {

--- a/src/imgui/backends/imgui_d3d9.cpp
+++ b/src/imgui/backends/imgui_d3d9.cpp
@@ -176,7 +176,7 @@ ImGui_ImplDX9_RenderDrawData (ImDrawData* draw_data)
       memcpy (
         &vtx_dst->col, &u32_color, sizeof (uint32_t)); // RGBA --> ARGB for DirectX9
 
-      if (config.imgui.render.disable_alpha)
+      if (config.imgui.render.disable_alpha && false)
       {
         ImU32 u32_dst =
           vtx_dst->col;////ImColor (ImVec4 (vtx_dst->col [0], vtx_dst->col [1], vtx_dst->col [2], vtx_dst->col [3]));

--- a/src/imgui/backends/imgui_gl3.cpp
+++ b/src/imgui/backends/imgui_gl3.cpp
@@ -109,7 +109,7 @@ ImGui_ImplGL3_RenderDrawData (ImDrawData* draw_data)
     const ImDrawList* cmd_list          = draw_data->CmdLists [n];
     const ImDrawIdx*  idx_buffer_offset = nullptr;
 
-    if (config.imgui.render.disable_alpha)
+    if (config.imgui.render.disable_alpha && false)
     {
       for (INT i = 0; i < cmd_list->VtxBuffer.Size; i++)
       {


### PR DESCRIPTION
I am not sure of the original intention of the current "boost alpha for visibility" method, but it results in lines in the frame pacing graphs and various other elements to be hidden or colored incorrectly, and is general something users occasionally complain about.

This pull request temporarily disables the original alpha boost and moves over to just defining the ImGuiCol_WindowBg alpha component to `1.0f` when `Disable Transparency` is enabled. The change is made at the start of a new frame, which allows it to affect all widgets as well.

* `Disable Transparency` has the following tooltip: `Resolves UI flicker in frame-doubled games`. I would assume the same applies to this approach, but I am unaware of what game that tooltip refers to, so I cannot test this myself.

**Transparency Enabled:**
![image](https://user-images.githubusercontent.com/10578344/187053675-ad8327ed-e70d-4cbd-a385-84d363a4d649.png)

**Transparency Disabled:**
![image](https://user-images.githubusercontent.com/10578344/187053682-7ff0fc0c-b3f9-4532-ad53-6d1567ba2554.png)
