### PR TITLE
Fix compilation with latest toolchain

### DIFF
--- a/include/SpecialK/thread.h
+++ b/include/SpecialK/thread.h
@@ -27,6 +27,7 @@
 #include <Windows.h>
 #include <avrt.h>
 #include <intsafe.h>
+#include <string>
 
 namespace sk
 {


### PR DESCRIPTION
Attempting to compile SpecialK with MSVC 14.34.31933 gives errors because the <string> header is not available to be referenced in SpecialK's "thread.h" header.

I don't know what changed in the toolchain such that this used to work but doesn't work anymore, but the problem is fixed by explicitly including <string> in "thread.h".

This change cannot introduce problems when using older toolchains because including <string> multiple times is harmless.