### PR TITLE
Fix SK_File_GetSize for symlinks

### DIFF
--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -2316,6 +2316,18 @@ SK_File_GetSize (const wchar_t* wszFile)
                                GetFileExInfoStandard,
                                  &file_attrib_data ) )
   {
+    if ( file_attrib_data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT )
+    {
+      // If the target at wszFile is a symlink, the GetFileAttributesEx
+      // function always returns a file size of zero. To get the size of the
+      // file pointed to by the symlink, we can use _wstat64 instead.
+      struct _stat64 buffer;
+      if ( _wstat64( wszFile, &buffer ) != 0 )
+      {
+        return 0ULL;
+      }
+      return buffer.st_size;
+    }
     return ULARGE_INTEGER { file_attrib_data.nFileSizeLow,
                             file_attrib_data.nFileSizeHigh }.QuadPart;
   }


### PR DESCRIPTION
SpecialK currently exhibits various problems when dealing with symlinks. For example, if a configuration file is a symlink to some other file, SpecialK will completely ignore that configuration file. This causes problems for me because I use symlinks with some regularity.

It turns out the root cause is that SpecialK's function for checking the size of a file does not work for symlinks because the Windows API call that it uses (GetFileAttributesEx) always returns a file size of zero if the specified target is a symlink. However, the _wstat64 function works correctly for symlinks.

One possible solution would be to completely replace the use of GetFileAttributesEx with _wstat64 instead. However, there are some sutble differences between the two functions and I don't want to risk introducing bugs by doing that. Instead, this change explicitly checks if the target is a symlink and, if so, uses _wstat64 in that case only. This cannot introduce any regressions because the code is currently completely broken for symlinks, so this can only make it better, not worse.