### PR TITLE
Fix OSD font size

### DIFF
--- a/include/SpecialK/control_panel.h
+++ b/include/SpecialK/control_panel.h
@@ -60,6 +60,9 @@ void SK_ImGui_AdjustCursor       (void);
 //
 namespace SK_ImGui
 {
+  float
+  SanitizeFontGlobalScale (float scale);
+
   bool
   VerticalToggleButton (const char *text, bool *v);
 

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -176,6 +176,13 @@ bool SK_ImGui_WantRestart = false;
 // Special K Extensions to ImGui
 namespace SK_ImGui
 {
+
+  float
+  SanitizeFontGlobalScale (float scale)
+  {
+    return std::max (1.0f, std::min (5.0f, scale));
+  }
+
   bool
   VerticalToggleButton (const char *text, bool *v)
   {
@@ -3624,7 +3631,7 @@ SK_ImGui_ControlPanel (void)
              = int (
   static_cast <float>
    (ImGui::CalcTextSize (szTitle, nullptr, true).x)
-          * 1.075f );
+          * 1.075f / io.FontGlobalScale );
 
   static bool first_frame = true;
   bool        open        = true;
@@ -3637,10 +3644,7 @@ SK_ImGui_ControlPanel (void)
       ImGuiConfigFlags_NavEnableSetMousePos;
 
     // Range-restrict for sanity!
-    config.imgui.scale =
-           std::max (1.0f,
-           std::min (5.0f,
-    config.imgui.scale));
+    config.imgui.scale = SK_ImGui::SanitizeFontGlobalScale (config.imgui.scale);
 
     io.FontGlobalScale =
     config.imgui.scale;
@@ -4013,8 +4017,7 @@ SK_ImGui_ControlPanel (void)
       {
         // ImGui does not perform strict parameter validation,
         //   and values out of range for this can be catastrophic.
-        config.imgui.scale =
-          std::max (1.0f, std::min (5.0f, config.imgui.scale));
+        config.imgui.scale = SK_ImGui::SanitizeFontGlobalScale (config.imgui.scale);
         io.FontGlobalScale = config.imgui.scale;
       }
 

--- a/src/osd/text.cpp
+++ b/src/osd/text.cpp
@@ -631,6 +631,8 @@ SK_InstallOSD (void)
     SK_SetOSDScale (config.osd.scale);
     SK_SetOSDPos   (config.osd.pos_x, config.osd.pos_y);
     SK_SetOSDColor (config.osd.red,   config.osd.green, config.osd.blue);
+    ImGui::GetIO ().FontGlobalScale = SK_ImGui::SanitizeFontGlobalScale (
+      config.imgui.scale);
   }
 }
 


### PR DESCRIPTION
The on-screen display feature of SpecialK ("OSD") renders certain text on the screen depending on user preferences, such as displaying the current FPS of the game.

The effective font size used for the OSD is the product of two independent configuration variables: `osd.viewport.scale` and `imgui.scale`. However, SpecialK doesn't do anything with the latter of these variables until the user opens the control panel overlay for the first time (e.g., by pressing Ctrl+Shift+Backspace). As a result, the first time the user opens the control panel, the font size of the OSD suddenly changes by a multiplicative factor equal to `imgui.scale`. This is a strange behavior that cannot be intentional.

This changeset ensures that the font size used for the OSD does not change merely because the user opens the control panel for the first time since starting the game. This requires two changes: first, we take into account the value of `imgui.scale` when first printing the OSD; and, second, we change the calcuation used for the width of the control panel overlay to take into the account that `imgui.scale` might already been processed when the control panel is first opened.