### PR TITLE
[Hatsune Miku: Project DIVA Mega Mix+] Addresses for the 1.03 game version.

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -2397,8 +2397,9 @@ auto DeclKeybind =
         // 1.00: 0x2C3201
         // 1.01: 0x2C37B1, File Location: 0x2C2801
         // 1.02: 0x2C3681, File Location: 0x2C26D0
+        // 1.03: 0x2C36C1, File Location: 0x2C26F0
         auto win_ver_check_addr =
-          ((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x2C3681);
+          ((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x2C36C1);
         auto win_ver_check_pattern = "\x48\x8B\xCF";
 
         DWORD dwOrigProt =                                     PAGE_EXECUTE_READ;

--- a/src/plugins/unclassified.cpp
+++ b/src/plugins/unclassified.cpp
@@ -1281,14 +1281,14 @@ SK_HatsuneMiku_BeginFrame (void)
 
   // 1.00: 0x14B2A78
   // 1.01: 0x14ACA68
-  // 1.02: 0x14ABBB8
+  // 1.02, 1.03: 0x14ABBB8
   static uint32_t* puiGameLimit =
         (uint32_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x14ABBB8);
 
-  // Pointer at DivaMegaMix.exe+, Offset=780h
+  // Pointer at DivaMegaMix.exe, Offset=780h
   // 1.00: 0x114EFF8
   // 1.01: 0x1148FC8
-  // 1.02: 0x11481E8
+  // 1.02, 1.03: 0x11481E8
   static auto menu_flag_addr =
       *(uintptr_t *)((uintptr_t)SK_Debug_GetImageBaseAddr () + 0x11481E8) + 0x780;
 


### PR DESCRIPTION
Updated addresses for the 1.03 game version. The game has been updated again by a miracle from SEGA. 😔

In my tests everything seems to be ok. I compared the addresses with version 1.02 of the game on IDA again.