### PR TITLE
Fix dgVoodoo plugin detection for local ddraw/d3d8

### DIFF
--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -455,6 +455,7 @@ DllMain ( HMODULE hModule,
       ////if (dll_isolation_lvl >= 3)                  return EarlyOut (FALSE);
 
       SK_TLS_Acquire ();
+      SK_EstablishRootPath ();
 
       if (dll_isolation_lvl >  0)                  return EarlyOut (TRUE);
 


### PR DESCRIPTION
https://github.com/SpecialKO/SpecialK/blob/12c62b332f6aae736bbf06dc4913844df3e7e5d4/src/SpecialK.cpp#L905-L910

`<SpecialK>\PlugIns\ThirdParty\dgVoodoo` folder could not be detected for local injection (ddraw/d3d8.dll) because `SK_EstablishRootPath()` was not called and `SK_GetInstallPath()` returned an empty path as a result.