### PR TITLE
Fix ClCompile errors in libSKinHook.vcxproj

### DIFF
--- a/depends/derivative/SKinHook/build/libSKinHook.vcxproj
+++ b/depends/derivative/SKinHook/build/libSKinHook.vcxproj
@@ -122,7 +122,7 @@
       <AssemblerOutput>All</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
       <BrowseInformation>false</BrowseInformation>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <DiagnosticsFormat>Caret</DiagnosticsFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4005;4201;4702;4061;4714;4820;5045</DisableSpecificWarnings>
@@ -181,7 +181,7 @@
       <AssemblerOutput>All</AssemblerOutput>
       <UseUnicodeForAssemblerListing>true</UseUnicodeForAssemblerListing>
       <BrowseInformation>false</BrowseInformation>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>None</DebugInformationFormat>
       <DisableSpecificWarnings>4005;4201;4702;4061;4714;4820;5045</DisableSpecificWarnings>
       <UndefinePreprocessorDefinitions>__midl</UndefinePreprocessorDefinitions>
       <AdditionalOptions>/Zo /Gw /Gm- /O0 /GR /cgthreads8 /Zf %(AdditionalOptions)</AdditionalOptions>
@@ -250,6 +250,7 @@
       <SDLCheck>false</SDLCheck>
       <DisableSpecificWarnings>4005;4201;4702;4061;4714;4820;5045</DisableSpecificWarnings>
       <IntelJCCErratum>true</IntelJCCErratum>
+      <DebugInformationFormat>None</DebugInformationFormat>
     </ClCompile>
     <Lib />
     <ProjectReference />

--- a/depends/derivative/SKinHook/build/libSKinHook.vcxproj
+++ b/depends/derivative/SKinHook/build/libSKinHook.vcxproj
@@ -303,6 +303,7 @@
       <DisableSpecificWarnings>4005;4201;4702;4061;4714;4820;5045</DisableSpecificWarnings>
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <IntelJCCErratum>true</IntelJCCErratum>
+      <DebugInformationFormat>None</DebugInformationFormat>
     </ClCompile>
     <Lib />
     <Lib />


### PR DESCRIPTION
This disables the DebugInformationFormat for libSKinHook which forces the GitHub Actions jobs to fail.