### PR TITLE
Prevent AsyncInit from re-enabling itself in Non-OGL Unity games

### DIFF
--- a/src/render/render_backend.cpp
+++ b/src/render/render_backend.cpp
@@ -492,7 +492,7 @@ SK_BootOpenGL (void)
       return;
   }
 
-  if (! config.compatibility.init_on_separate_thread)
+  if (SK_GetDLLRole () == DLL_ROLE::OpenGL && (! config.compatibility.init_on_separate_thread))
   {
     config.compatibility.init_on_separate_thread = true;
     return;


### PR DESCRIPTION
Fixed `AsyncInit=false` resetting to `AsyncInit=true` in Non-OpenGL Unity games. Some D3D9 games can use `AsyncInit=false` to make D3D9Ex/FlipEx work with global injection.