### PR TITLE
Fix SK_GetThreadDescription on Win7 and 8.1

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -78,7 +78,8 @@ SK_Thread_QueryNameFromOS (DWORD dwTid)
                                 dwTid ) );
 
     wchar_t                                          *wszThreadName = nullptr;
-    if (SUCCEEDED (SK_GetThreadDescription (hThread, &wszThreadName)))
+    if (nullptr != SK_GetThreadDescription &&
+        SUCCEEDED (SK_GetThreadDescription (hThread, &wszThreadName)))
     {
       if ( wszThreadName != nullptr &&
           *wszThreadName != L'\0' ) // Empty strings are not useful :)


### PR DESCRIPTION
Fixes crash on e.g. Windows 7, and probably 8.1 too.