### PR TITLE
Don't hook Serious Sam Fusion 2017's window process

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1353,6 +1353,7 @@ enum class SK_GAME_ID
   DiabloIV,                     // Diablo IV.exe
   CallOfDuty,                   // CoDSP.exe, CoDMP.exe (???)
   RatchetAndClank_RiftApart,    // RiftApart.exe
+  SeriousSamFusion2017,         // Sam2017.exe / Sam2017_Unrestricted.exe
 
   UNKNOWN_GAME               = 0xffff
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -259,6 +259,11 @@ SK_GetCurrentGameID (void)
         current_game = SK_GAME_ID::FinalFantasy7Remake;
       }
 
+      else if ( StrStrIW ( SK_GetHostApp (), L"Sam2017" ) )
+      {
+        current_game = SK_GAME_ID::SeriousSamFusion2017;
+      }
+
       else if ( StrStrIW ( SK_GetHostApp (), L"ACValhalla" ) )
       {
         current_game = SK_GAME_ID::AssassinsCreed_Valhalla;
@@ -2989,6 +2994,11 @@ auto DeclKeybind =
       case SK_GAME_ID::HaloInfinite:
         // Prevent VRR disable when using game's framerate limiter
         config.render.framerate.sync_interval_clamp = 1;
+        break;
+
+      case SK_GAME_ID::SeriousSamFusion2017:
+        // Prevent crash on launch due to 'Signature verification of executable failed.'
+        config.window.dont_hook_wndproc = true;
         break;
 
       case SK_GAME_ID::ForzaHorizon5:


### PR DESCRIPTION
Prevents crash on launch due to 'Signature verification of executable failed' by having Special K not hook the window process.