### PR TITLE
Added ASI files to the plugin file dialog

### DIFF
--- a/src/control_panel/cfg_plugins.cpp
+++ b/src/control_panel/cfg_plugins.cpp
@@ -335,7 +335,7 @@ SK::ControlPanel::PlugIns::Draw (void)
     }
 
     fileDialog.SetTitle       ("Select a Plug-In DLL");
-    fileDialog.SetTypeFilters (      { ".dll" }      );
+    fileDialog.SetTypeFilters (  { ".dll", ".asi" }  );
 
     fileDialog.Display ();
 

--- a/src/control_panel/cfg_plugins.cpp
+++ b/src/control_panel/cfg_plugins.cpp
@@ -331,11 +331,10 @@ SK::ControlPanel::PlugIns::Draw (void)
 
     if (ImGui::Button ("Add Plug-In"))
     {
+      fileDialog.SetTitle       ("Select a Plug-In DLL");
+      fileDialog.SetTypeFilters (  { ".dll", ".asi" }  );
       fileDialog.Open ();
     }
-
-    fileDialog.SetTitle       ("Select a Plug-In DLL");
-    fileDialog.SetTypeFilters (  { ".dll", ".asi" }  );
 
     fileDialog.Display ();
 


### PR DESCRIPTION
This just adds ".asi" to the type filter used by the plugin file dialog, which allows those files to be listed by default alongside DLL files.

No other changes seems to be needed for compatibility.