### PR TITLE
Added .editorconfig to force 2 spaces as indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Adding this file tells Visual Studio to disregard user preferences (default: 4 spaces as indent) and instead use 2 spaces as indent across all files. This ensures the same basic formatting style among contributors.

SKIF has used the same sort of file for awhile now.