### PR TITLE
Blacklist Epic Games Launcher

### DIFF
--- a/include/SpecialK/injection/blacklist.h
+++ b/include/SpecialK/injection/blacklist.h
@@ -215,6 +215,7 @@ static constexpr constexpr_module_s::list_type __blacklist = {
 
   L"pwahelper.exe",
 
+  L"epicgameslauncher.exe",
   L"epicwebhelper.exe",
   L"steamwebhelper.exe",
   L"galaxyclient helper.exe",


### PR DESCRIPTION
EpicGamesLauncher.exe is apparently not blacklisted and can create a profile folder as a result. Let's blacklist it!