### PR TITLE
Moved ImGui debug options to a submenu

### DIFF
--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -3654,21 +3654,25 @@ SK_ImGui_ControlPanel (void)
           eula.show = true;
 
         ImGui::Separator ();
-        
-        if (ImGui::MenuItem ("ImGui -> Demo",      "ImGui Debug", &selected))
-          imgui_demo    = true;
 
-        if (ImGui::MenuItem ("ImGui -> Debug Log", "ImGui Debug", &selected))
-          imgui_debug   = true;
+        if (ImGui::BeginMenu ("ImGui Debug"))
+        {
+          ImGui::SeparatorText ("ImGui Debug");
 
-        if (ImGui::MenuItem ("ImGui -> Metrics",   "ImGui Debug", &selected))
-          imgui_metrics = true;
+          ImGui::MenuItem  ("Demo",      "", &imgui_demo);
 
-        if (ImGui::MenuItem ("ImGui -> About",     "ImGui Debug", &selected))
-          imgui_about   = true;
+          ImGui::MenuItem  ("Debug Log", "", &imgui_debug);
 
-        if (ImGui::MenuItem ("ImPlot -> Demo",     "ImPlot Debug",&selected))
-          implot_demo   = true;
+          ImGui::MenuItem  ("Metrics",   "", &imgui_metrics);
+
+          ImGui::MenuItem  ("About",     "", &imgui_about);
+
+          ImGui::SeparatorText ("ImPlot Debug");
+
+          ImGui::MenuItem  (" Demo",     "",&implot_demo);
+
+          ImGui::EndMenu   ( );
+        }
 
         ImGui::Separator ();
 


### PR DESCRIPTION
This moves the ImGui/ImPlot options to a new submenu and allows them to be toggled.
Also uses `ImGui::SeparatorText()` for some fancy header separators.

![image](https://github.com/SpecialKO/SpecialK/assets/10578344/ce6271b3-b0c1-48d8-8414-2c11c7a17c01)
