### PR TITLE
Expect 85 KB minimum for steam_api.dll

### DIFF
--- a/src/steam/steam_api.cpp
+++ b/src/steam/steam_api.cpp
@@ -5015,7 +5015,7 @@ SK_Steam_PiratesAhoy (void)
 
   // DLL is too small to be legit, don't enable SteamAPI features
   if ( SK::SteamAPI::steam_size > 0LL &&
-       SK::SteamAPI::steam_size < (1024LL * 92LL) )
+       SK::SteamAPI::steam_size < (1024LL * 85LL) )
   {
     verdict = 0x68992;
   }


### PR DESCRIPTION
**The Last Remnant** is a Steam game from 2009 with a super-old copy of `steam_api.dll` from September 5, 2008.

This DLL file is only 85.2 KB (87,288 bytes), which falls below the 92 KB minimum that SK currently requires.

Lowering the floor a tiny amount down to 85 KB brings us just beneath and makes this game evaluate as valid.