### PR TITLE
Disable tearing + waitable when using Flip->BitBlt override

### DIFF
--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -4681,6 +4681,7 @@ SK_DXGI_CreateSwapChain_PreInit (
                pDesc->SwapEffect =                         DXGI_SWAP_EFFECT_SEQUENTIAL;
 
       pDesc->Flags &= ~DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+      pDesc->Flags &= ~DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
     }
 
     if (! config.window.res.override.isZero ())

--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -4679,6 +4679,8 @@ SK_DXGI_CreateSwapChain_PreInit (
                pDesc->SwapEffect =                         DXGI_SWAP_EFFECT_DISCARD;
       else if (pDesc->SwapEffect == (DXGI_SWAP_EFFECT)DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL)
                pDesc->SwapEffect =                         DXGI_SWAP_EFFECT_SEQUENTIAL;
+
+      pDesc->Flags &= ~DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
     }
 
     if (! config.window.res.override.isZero ())


### PR DESCRIPTION
Games that natively use either the allow tearing or waitable swapchain DXGI flags will fail being overridden to BitBlt because of that flag, so let's ensure those are never ticked.