### PR TITLE
Show swap chain overrides Special K is applying

### DIFF
--- a/include/SpecialK/render/backend.h
+++ b/include/SpecialK/render/backend.h
@@ -207,6 +207,7 @@ public:
   bool                    fullscreen_exclusive = false;
   uint64_t                framebuffer_flags    = 0x00;
   int                     present_interval     = 0; // Present interval on last call to present
+  int                     present_interval_orig = 0; // Application preference
   float                   ui_luminance         = 325.0_Nits;
   bool                    ui_srgb              = true;
   bool                    srgb_stripped        = false; // sRGB may be stripped from swapchains for advanced features to work

--- a/src/control_panel/cfg_d3d11.cpp
+++ b/src/control_panel/cfg_d3d11.cpp
@@ -1817,6 +1817,7 @@ SK_ImGui_SummarizeDXGISwapchain (IDXGISwapChain* pSwapDXGI)
                   &swap_flag_count     );
 
       extern UINT uiOriginalBltSampleCount;
+      extern DXGI_SWAP_CHAIN_DESC _ORIGINAL_SWAP_CHAIN_DESC;
 
       ImGui::BeginTooltip      ();
       ImGui::PushStyleColor    (ImGuiCol_Text, ImVec4 (0.95f, 0.95f, 0.45f, 1.0f));
@@ -1854,7 +1855,14 @@ SK_ImGui_SummarizeDXGISwapchain (IDXGISwapChain* pSwapDXGI)
       ImGui::PushStyleColor  (ImGuiCol_Text, ImVec4 (1.0f, 1.0f, 1.0f, 1.0f));
       ImGui::Text            ("%hs",                SK_DXGI_FormatToStr (swap_desc.Format).data ());
       ImGui::Text            ("%ux%u",                                   swap_desc.Width, swap_desc.Height);
-      ImGui::Text            ("%lu",                                     std::max (1U, swap_desc.BufferCount));
+      
+      if (_ORIGINAL_SWAP_CHAIN_DESC.OutputWindow == SK_GetGameWindow ( ) &&
+          _ORIGINAL_SWAP_CHAIN_DESC.BufferCount  != swap_desc.BufferCount)
+        ImGui::Text            ("%lu %hs %lu",                             std::max (1U, _ORIGINAL_SWAP_CHAIN_DESC.BufferCount),  (const char*)u8"\u2192",
+                                                                           std::max (1U, swap_desc.BufferCount));
+      else
+        ImGui::Text            ("%lu",                                     std::max (1U, swap_desc.BufferCount));
+
       if ((! fullscreen_desc.Windowed) && fullscreen_desc.Scaling          != DXGI_MODE_SCALING_UNSPECIFIED)
         ImGui::Text          ("%hs",        SK_DXGI_DescribeScalingMode (fullscreen_desc.Scaling));
       if ((! fullscreen_desc.Windowed) && fullscreen_desc.ScanlineOrdering != DXGI_MODE_SCANLINE_ORDER_UNSPECIFIED)
@@ -1865,7 +1873,7 @@ SK_ImGui_SummarizeDXGISwapchain (IDXGISwapChain* pSwapDXGI)
       if (rb.present_interval == 0)
         ImGui::Text          ("%u: VSYNC OFF",                           rb.present_interval);
       else if (rb.present_interval == 1)
-        ImGui::Text ("%u: Normal V-SYNC", rb.present_interval);
+        ImGui::Text          ("%u: Normal V-SYNC",                       rb.present_interval);
       else if (rb.present_interval == 2)
         ImGui::Text          ("%u: 1/2 Refresh V-SYNC",                  rb.present_interval);
       else if (rb.present_interval == 3)
@@ -1874,7 +1882,15 @@ SK_ImGui_SummarizeDXGISwapchain (IDXGISwapChain* pSwapDXGI)
         ImGui::Text          ("%u: 1/4 Refresh V-SYNC",                  rb.present_interval);
       else
         ImGui::Text          ("%u: UNKNOWN or Invalid",                  0);
-      ImGui::Text            ("%hs",            SK_DXGI_DescribeSwapEffect (swap_desc.SwapEffect));
+
+      if (_ORIGINAL_SWAP_CHAIN_DESC.OutputWindow == SK_GetGameWindow ( ) &&
+          _ORIGINAL_SWAP_CHAIN_DESC.SwapEffect   != swap_desc.SwapEffect)
+        ImGui::Text            ("%hs %hs %hs",    SK_DXGI_DescribeSwapEffect (_ORIGINAL_SWAP_CHAIN_DESC.SwapEffect), (const char*)u8"\u2192",
+                                                  SK_DXGI_DescribeSwapEffect (swap_desc.SwapEffect));
+      else
+        ImGui::Text            ("%hs",            SK_DXGI_DescribeSwapEffect (swap_desc.SwapEffect));
+
+
       if  (swap_desc.SampleDesc.Count > 1)
         ImGui::Text          ("%u",                                         swap_desc.SampleDesc.Count);
       else if (uiOriginalBltSampleCount > 1)

--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -50,7 +50,8 @@
 #include <VersionHelpers.h>
 
 BOOL _NO_ALLOW_MODE_SWITCH = FALSE;
-DXGI_SWAP_CHAIN_DESC _ORIGINAL_SWAP_CHAIN_DESC = { };
+DXGI_SWAP_CHAIN_DESC  _ORIGINAL_SWAP_CHAIN_DESC = { };
+DXGI_SWAP_CHAIN_DESC1 _ORIGINAL_SWAP_CHAIN_DESC1 = { };
 
 #include <../depends/include/DirectXTex/d3dx12.h>
 
@@ -2881,7 +2882,8 @@ SK_DXGI_PresentBase ( IDXGISwapChain         *This,
     if (interval == SK_NoPreference)
         interval = SyncInterval;
 
-    rb.present_interval = interval;
+    rb.present_interval      = interval;
+    rb.present_interval_orig = SyncInterval;
 
     if (interval != 0 || rb.fullscreen_exclusive) // FSE can't use this flag
       flags &= ~DXGI_PRESENT_ALLOW_TEARING;
@@ -4557,7 +4559,7 @@ SK_DXGI_CreateSwapChain_PreInit (
   if (pDesc != nullptr)
   {
     orig_desc = *pDesc;
-    _ORIGINAL_SWAP_CHAIN_DESC = orig_desc;
+    _ORIGINAL_SWAP_CHAIN_DESC = *pDesc;
 
     if (SK_GetCurrentGameID () == SK_GAME_ID::Elex2)
     {
@@ -5046,6 +5048,8 @@ SK_DXGI_CreateSwapChain_PreInit (
   if ( pDesc1 != nullptr &&
        pDesc  != nullptr && translated )
   {
+    _ORIGINAL_SWAP_CHAIN_DESC1 = *pDesc1;
+
     pDesc1->BufferCount = pDesc->BufferCount;
     pDesc1->BufferUsage = pDesc->BufferUsage;
     pDesc1->Flags       = pDesc->Flags;

--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -50,6 +50,7 @@
 #include <VersionHelpers.h>
 
 BOOL _NO_ALLOW_MODE_SWITCH = FALSE;
+DXGI_SWAP_CHAIN_DESC _ORIGINAL_SWAP_CHAIN_DESC = { };
 
 #include <../depends/include/DirectXTex/d3dx12.h>
 
@@ -4556,6 +4557,7 @@ SK_DXGI_CreateSwapChain_PreInit (
   if (pDesc != nullptr)
   {
     orig_desc = *pDesc;
+    _ORIGINAL_SWAP_CHAIN_DESC = orig_desc;
 
     if (SK_GetCurrentGameID () == SK_GAME_ID::Elex2)
     {


### PR DESCRIPTION
Quick and dirty proof of concept of how swapchain overrides could be detailed in the framebuffer and resolution tooltip, to make it more clear to users what the original value was and what it is being overriden to.