### PR TITLE
Fixes bottom-aligned OSD

### DIFF
--- a/src/osd/text.cpp
+++ b/src/osd/text.cpp
@@ -1582,7 +1582,7 @@ SK_DrawOSD (void)
       OSD_END
     }
 
-    OSD_P_PRINTF "\n" OSD_END
+    OSD_P_PRINTF "\n\n" OSD_END
   }
 
   // Avoid unnecessary MMIO when the user has the OSD turned off
@@ -1803,6 +1803,13 @@ auto SK_CountLines =
     line [num_lines];
     line [num_lines] == '\n' ? num_lines++ :
                                    *line++ );
+
+  // Each visible section of the OSD adds newlines at the end to
+  //   push any follow-up sections down (solves various complex
+  //     combinations), which means we need to ignore the final
+  //       couple of newlines here...
+  if (num_lines >= 2)
+      num_lines -= 2;
 
   return
     num_lines;


### PR DESCRIPTION
As part of the recent #107 pull request, to fix newline issues with more complex combinations I had to move adding newlines to the top of new sections to instead add newlines to the bottom of a printed section.

This however broke the bottom-aligned OSD, as it always detected the final two newlines of the last printed section and so pushed the OSD up a bit more.

This solves that issue by ignoring the two final newlines.