### PR TITLE
Create a base config if loading ReShade

### DIFF
--- a/src/control_panel/cfg_plugins.cpp
+++ b/src/control_panel/cfg_plugins.cpp
@@ -456,6 +456,40 @@ SK::ControlPanel::PlugIns::Draw (void)
 
       if (reshade_official)
       {
+        std::wstring reshade_ini  = 
+          SK_FormatStringW (LR"(%ws\ReShade.ini)",      SK_GetConfigPath ( )),
+                     shader_dir   = 
+          SK_FormatStringW (LR"(%ws\ReShade\Shaders\)", SK_GetConfigPath ( )),
+                     textures_dir = 
+          SK_FormatStringW (LR"(%ws\ReShade\Textures)", SK_GetConfigPath ( ));
+
+        if (! PathFileExists (reshade_ini.c_str()))
+        {
+          std::wofstream reshade_ini_fs (reshade_ini.c_str());
+          if (reshade_ini_fs.is_open())
+          {
+            std::wstring reshade_ini_base = SK_FormatStringW (
+LR"([GENERAL]
+EffectSearchPaths=.\ReShade\Shaders\**,%ws\PlugIns\ThirdParty\ReShade\Shaders\**
+TextureSearchPaths=.\ReShade\Textures\**,%ws\PlugIns\ThirdParty\ReShade\Textures\**)",
+            SK_GetInstallPath ( ), SK_GetInstallPath ( ));
+
+            // Create any missing directories
+            std::error_code ec;
+            if (! std::filesystem::exists (            shader_dir,   ec))
+                  std::filesystem::create_directories (shader_dir,   ec);
+            if (! std::filesystem::exists (            textures_dir, ec))
+                  std::filesystem::create_directories (textures_dir, ec);
+
+            reshade_ini_fs.write (
+              reshade_ini_base.c_str(),
+              reshade_ini_base.length()
+            );
+
+            reshade_ini_fs.close();
+          }
+        }
+
         // Non-Unity engines benefit from a small (0 ms) injection delay
         if (config.system.global_inject_delay < 0.001)
         {   config.system.global_inject_delay = 0.001;


### PR DESCRIPTION
This creates a base config for ReShade that tells it to load shaders and textures both from SK's game profile folder as well as the folder where the DLL files are located in.

Folders that will be processed by ReShade:

Shaders:
```
Special K\Profiles\<game>\ReShade\Shaders\
Special K\PlugIns\ThirdParty\ReShade\Shaders\
```

Textures:
```
Special K\Profiles\<game>\ReShade\Textures\
Special K\PlugIns\ThirdParty\ReShade\Textures\
```