### PR TITLE
Added ability to specify target input latency in (ms) or (%)

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -611,7 +611,10 @@ struct sk_config_t
         float delay_bias           =  0.0f;
         bool  auto_bias            = false;
         float max_auto_bias        = 0.75f;
-        float auto_bias_target     = 0.85f;
+        struct auto_bias_target_s {
+          float ms                 = 0.85f;
+          float percent            = 0.0F;
+        } auto_bias_target;
         bool  show_fcat_bars       = false; // Not INI-persistent
 
         bool flush_before_present  = true;

--- a/src/framerate.cpp
+++ b/src/framerate.cpp
@@ -503,10 +503,37 @@ SK_ImGui_LatentSyncConfig (void)
           config.render.framerate.latent_sync.max_auto_bias = fBiasPercent > 0.0f ? fBiasPercent / 100.0f
                                                                                   : 0.0f;
 
-        if (ImGui::InputFloat ("Target Input Latency (ms)", &config.render.framerate.latent_sync.auto_bias_target))
+        bool auto_bias_target_in_ms = config.render.framerate.latent_sync.auto_bias_target.percent == 0.0f;
+
+        if (ImGui::Checkbox ("Target Input Latency in milliseconds", &auto_bias_target_in_ms))
         {
-          config.render.framerate.latent_sync.auto_bias_target =
-            std::clamp (config.render.framerate.latent_sync.auto_bias_target, 0.0f, 25.0f);
+          if (auto_bias_target_in_ms) {
+            config.render.framerate.latent_sync.auto_bias_target.ms      = 0.85f;
+            config.render.framerate.latent_sync.auto_bias_target.percent = 0.0f;
+          }
+
+          else {
+            config.render.framerate.latent_sync.auto_bias_target.percent = 0.5f;
+            config.render.framerate.latent_sync.auto_bias_target.ms      = 0.0f;
+          }
+        }
+
+        if (auto_bias_target_in_ms)
+        {
+          if (ImGui::InputFloat ("Target Input Latency", &config.render.framerate.latent_sync.auto_bias_target.ms))
+          {
+            config.render.framerate.latent_sync.auto_bias_target.ms =
+              std::clamp (config.render.framerate.latent_sync.auto_bias_target.ms, 0.0f, 25.0f);
+          }
+        }
+
+        else
+        {
+          float fAutoBiasTargetPercent = config.render.framerate.latent_sync.auto_bias_target.percent * 100.0f;
+
+          if (ImGui::SliderFloat ("Target Input Latency", &fAutoBiasTargetPercent, 0.000001f, 100.0f, "%4.1f%%"))
+            config.render.framerate.latent_sync.auto_bias_target.percent = fAutoBiasTargetPercent > 0.0f ? fAutoBiasTargetPercent / 100.0f
+                                                                                                         : 0.000001f;
         }
 
         if (ImGui::IsItemHovered ())
@@ -1935,7 +1962,19 @@ SK::Framerate::Limiter::wait (void)
 
         float delta = 0.0f;
 
-        if (latency_avg.getInput () > (config.render.framerate.latent_sync.auto_bias_target * 1.05f))
+        float auto_bias_target_ms =
+          config.render.framerate.latent_sync.auto_bias_target.ms;
+        
+        float auto_bias_target_percent =
+          config.render.framerate.latent_sync.auto_bias_target.percent;
+
+        if (auto_bias_target_percent > 0.0f)
+        {
+          auto_bias_target_ms =
+            static_cast <float> ((latency_avg.getInput () + latency_avg.getDisplay ()) * (1.0f - auto_bias_target_percent));
+        }
+
+        if (latency_avg.getInput () > (auto_bias_target_ms * 1.05f))
         {
           delta = (float)effective_frametime () * SK_LatentSyncDeltaMultiplier;
 
@@ -1943,7 +1982,7 @@ SK::Framerate::Limiter::wait (void)
             SK_LatentSyncAlpha * config.render.framerate.latent_sync.delay_bias + (1.0f - SK_LatentSyncAlpha) * delta;
         }
 
-        else if (latency_avg.getInput () < (config.render.framerate.latent_sync.auto_bias_target * .95f))
+        else if (latency_avg.getInput () < (auto_bias_target_ms * .95f))
         {
           delta = (float)effective_frametime () * SK_LatentSyncDeltaMultiplier * SK_LatentSyncBackOffMultiplier;
 


### PR DESCRIPTION
When Latent Sync Auto-Bias is enabled, users can toggle a checkbox to specify Target Input Latency in milliseconds (default behavior) or percentage (default value is 50%).

AutoBiasTargetInMs setting was renamed to AutoBiasTarget.

Now it works similarly to [Window.System] XOffset/YOffset setting, for example:
AutoBiasTarget=0.85 (milliseconds) or AutoBiasTarget=85.0% (percentage).

Milliseconds:
![image](https://github.com/SpecialKO/SpecialK/assets/129186721/6c8ec370-034c-4f78-b310-9de42dad5cbc)

Percentage:
![image](https://github.com/SpecialKO/SpecialK/assets/129186721/f251ae42-612d-4e9e-b74f-e4b696c0462b)