### PR TITLE
Fix Vulkan interop support for non-HDR swapchain

### DIFF
--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -389,6 +389,7 @@ SK_DXGI_PickHDRFormat ( DXGI_FORMAT fmt_orig, BOOL bWindowed,
   {
     TenBitSwap                       = true;
     config.render.output.force_10bpc = true;
+    __SK_HDR_UserForced              = true;
   }
 
   DXGI_FORMAT fmt_new = fmt_orig;


### PR DESCRIPTION
Commit 1b71cb0c introduced a hack to prevent NVIDIA's Vulkan/DXGI
interop swap chain from destroying itself if HDR is not enabled. The
hack was slightly revised in 349a391f.

Commit 677517f3 broke the hack because the new `__SK_HDR_UserForced`
variable will generally be `false` when using SDR, but the hack doesn't
do anything unless `__SK_HDR_UserForced` is set to `true`.

As a solution, this commit now sets `__SK_HDR_UserForced` to `true` when
setting up the hack that prevents NVIDIA's Vulkan/DXGI interop swap
chain from destroying itself if HDR is not enabled.

This fixes a bug reported here, which I also experienced:
   https://discord.com/channels/778539700981071872/778887425275199548/1199128518894821468
