### PR TITLE
Added ability to specify TargetFPS/BackgroundFPS as refresh rate factor

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3612,8 +3612,7 @@ auto DeclKeybind =
       {
         config.render.framerate.target_fps =
           static_cast <float> (
-            rb.windows.device.getDevCaps ().res.refresh *
-              (sk::narrow_cast <float> (numerator) / sk::narrow_cast <float> (denominator))
+            (rb.windows.device.getDevCaps ().res.refresh * numerator) / denominator
           );
       }
     }
@@ -3638,8 +3637,7 @@ auto DeclKeybind =
       {
         config.render.framerate.target_fps_bg =
           static_cast <float> (
-            rb.windows.device.getDevCaps ().res.refresh *
-              (sk::narrow_cast <float> (numerator) / sk::narrow_cast <float> (denominator))
+            (rb.windows.device.getDevCaps ().res.refresh * numerator) / denominator
           );
       }
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3604,7 +3604,7 @@ auto DeclKeybind =
   {
     if (target_fps.find (L'/') != std::wstring::npos)
     {
-      UINT numerator, denominator;
+      UINT numerator = 1, denominator = 1;
 
       swscanf (target_fps.c_str (), L"%i/%i", (INT*)&numerator, (INT*)&denominator);
 
@@ -3630,7 +3630,7 @@ auto DeclKeybind =
   {
     if (target_fps_bg.find (L'/') != std::wstring::npos)
     {
-      UINT numerator, denominator;
+      UINT numerator = 1, denominator = 1;
 
       swscanf (target_fps_bg.c_str (), L"%i/%i", (INT*)&numerator, (INT*)&denominator);
 


### PR DESCRIPTION
Users can now specify `TargetFPS` and `BackgroundFPS` as refresh rate factor:

- `TargetFPS=1/1`, `BackgroundFPS=1/2` and so on...

The factor value only applies on first launch and gets converted to a decimal value (actual FPS limit) for subsequent launches.