### PR TITLE
Set dxgi.deferred_isolation on GBF Relink to enable Render mods.

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1497,6 +1497,7 @@ enum class SK_GAME_ID
   StreetFighter6,               // StreetFighter6.exe
   StardewValley,                // Stardew Valley.exe
   DOOMEternal,                  // DOOMEternalx64vk.exe
+  GranblueFantasy_Relink,       // granblue_fantasy_relink.exe
 
   UNKNOWN_GAME               = 0xffff
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -249,7 +249,8 @@ SK_GetCurrentGameID (void)
           { L"CrashReport.exe",                        SK_GAME_ID::CrashReport                  },
           { L"StreetFighter6.exe",                     SK_GAME_ID::StreetFighter6               },
           { L"Stardew Valley.exe",                     SK_GAME_ID::StardewValley                },
-          { L"DOOMEternalx64vk.exe",                   SK_GAME_ID::DOOMEternal                  }
+          { L"DOOMEternalx64vk.exe",                   SK_GAME_ID::DOOMEternal                  },
+          { L"granblue_fantasy_relink.exe",            SK_GAME_ID::GranblueFantasy_Relink       }
         };
 
     first_check  = false;
@@ -3362,6 +3363,10 @@ auto DeclKeybind =
       case SK_GAME_ID::DOOMEternal:
         config.apis.NvAPI.vulkan_bridge   = 1;
         config.system.global_inject_delay = 0.0f;
+        break;
+
+      case SK_GAME_ID::GranblueFantasy_Relink:
+        config.render.dxgi.deferred_isolation = true; //Needed for render mods
         break;
 
       case SK_GAME_ID::AlanWake2:


### PR DESCRIPTION
Game requires d3d11 deferred mode to be enabled on SpecialK for the Mod Toolkit to work. 
(And i need my Dualsense button prompts)


![Granblue Fantasyː Relink 2024-02-01 19ː58ː52](https://github.com/SpecialKO/SpecialK/assets/8961085/db0ab7b2-ad6d-4292-8669-415c78872e45)
