### PR TITLE
Changed FPS limiter GUI constraints

### DIFF
--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5214,7 +5214,7 @@ SK_ImGui_ControlPanel (void)
                      : ImColor (0.73f, 0.73f, 0.73f).Value ) );
 
           if ( ImGui::DragFloat ( label, &target_mag,
-                                      1.0f, 24.0f, 166.0f, target > 0 ?
+                                      1.0f, 0.1f, 1000.0f, target > 0 ?
                           ( active ? "%6.3f fps  (Limit Engaged)" :
                                      "%6.3f fps  (~Window State)" )
                                                                   :


### PR DESCRIPTION
Addresses #138 by:

- Setting the FPS limiter GUI's constraints to 0.1-1000.

Notes:
- I tested that extremely low FPS limits down to 0.1 worked correctly without causing additional issues.
- I did not test high FPS limits (>166).
- I didn't test building this.