### PR TITLE
Detect D3D8/DDraw/Glide in SK_dgVoodoo_CheckForInterop (...)

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1118,7 +1118,6 @@ struct sk_config_t
 
     struct d3d9_s {
       bool   hook        =            true;
-      bool   translated  =           false;
       int    native_dxvk = SK_NoPreference;
       int    hook_next   = SK_NoPreference;
     } d3d9,

--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1157,6 +1157,7 @@ struct sk_config_t
     } D3DKMT;
 
     SK_RenderAPI last_known    = SK_RenderAPI::Reserved;
+    SK_RenderAPI translated    = SK_RenderAPI::None;
   } apis;
 
   struct system_s {

--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -975,11 +975,6 @@ SK_dgVoodoo_CheckForInterop (void)
       {
         config.apis.translated = it.second;
 
-        // Don't use dgVoodoo Plug-In if a game is already translated
-        config.apis.d3d8.hook  = false;
-        config.apis.ddraw.hook = false;
-        config.apis.glide.hook = false;
-
         if (config.apis.translated == SK_RenderAPI::D3D9)
         {
           config.apis.d3d9.hook   = false;
@@ -1381,6 +1376,10 @@ SK_EstablishDllRole (skWin32Module&& _sk_module)
         // Don't use dgVoodoo Plug-In if a game is already translated
         if (config.apis.translated != SK_RenderAPI::None)
         {
+          config.apis.d3d8.hook  = false;
+          config.apis.ddraw.hook = false;
+          config.apis.glide.hook = false;
+
           d3d8  = false;
           ddraw = false;
           glide = false;

--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -1373,6 +1373,13 @@ SK_EstablishDllRole (skWin32Module&& _sk_module)
         d3d8   |= (SK_GetModuleHandle (L"d3d8.dll")      != nullptr);
         ddraw  |= (SK_GetModuleHandle (L"ddraw.dll")     != nullptr);
 
+        // Don't use dgVoodoo Plug-In if a game is already translated
+        if (config.apis.translated != SK_RenderAPI::None)
+        {
+          d3d8  = false;
+          ddraw = false;
+        }
+
         if (config.apis.d3d8.hook && d3d8 && has_dgvoodoo)
         {
           if (SK_TryLocalWrapperFirst ({ L"d3d8.dll" }))

--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -1378,6 +1378,7 @@ SK_EstablishDllRole (skWin32Module&& _sk_module)
         {
           d3d8  = false;
           ddraw = false;
+          glide = false;
         }
 
         if (config.apis.d3d8.hook && d3d8 && has_dgvoodoo)

--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -975,6 +975,11 @@ SK_dgVoodoo_CheckForInterop (void)
       {
         config.apis.translated = it.second;
 
+        // Don't use dgVoodoo Plug-In if a game is already translated
+        config.apis.d3d8.hook  = false;
+        config.apis.ddraw.hook = false;
+        config.apis.glide.hook = false;
+
         if (config.apis.translated == SK_RenderAPI::D3D9)
         {
           config.apis.d3d9.hook   = false;

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -4718,39 +4718,33 @@ SK_ImGui_ControlPanel (void)
       }
     }
 
-          char szAPIName [32] = {             };
-    snprintf ( szAPIName, 32, "%ws",  rb.name );
+    char szAPIName [32] = { };
 
-    // Translation layers (D3D8->11 / D3D8->12 / DDraw->11 / DDraw->12 / D3D11On12)
+    // Translation layers (D3D9/D3D8/DDraw/Glide->11/12 / D3D11On12)
+    bool translated = config.apis.translated != SK_RenderAPI::None;
+
+    if (translated)
+    {
+      snprintf ( szAPIName, 32, "%ws", SK_Render_GetAPIName (config.apis.translated) );
+    }
+
+    else
+    {
+      snprintf ( szAPIName, 32, "%ws", rb.name );
+    }
+
     auto api_mask = static_cast <int> (rb.api);
 
-    bool translated_d3d9 =
-      config.apis.d3d9.translated;
-
     if (0x0 != (api_mask &  static_cast <int> (SK_RenderAPI::D3D12)) &&
-               (api_mask != static_cast <int> (SK_RenderAPI::D3D12)  || translated_d3d9))
+               (api_mask != static_cast <int> (SK_RenderAPI::D3D12)  || translated))
     {
-      if (translated_d3d9)
-      {
-        strncpy  (szAPIName, (const char *)u8"D3D9→12", 32);
-      }
-      else if (api_mask == static_cast <int> (SK_RenderAPI::DDrawOn12)  ||
-               api_mask == static_cast <int> (SK_RenderAPI::D3D8On12)   ||
-               api_mask == static_cast <int> (SK_RenderAPI::GlideOn12))
-      {
-        lstrcatA (szAPIName, (const char *)u8"→12");
-      }
-      else
-      {
-        lstrcatA (szAPIName, "On12");
-      }
+      lstrcatA (szAPIName, (const char *)u8"→12");
     }
 
     else if (0x0 != (api_mask &  static_cast <int> (SK_RenderAPI::D3D11)) &&
-                    (api_mask != static_cast <int> (SK_RenderAPI::D3D11)  || translated_d3d9))
+                    (api_mask != static_cast <int> (SK_RenderAPI::D3D11)  || translated))
     {
-      if (! translated_d3d9)lstrcatA (szAPIName, (const char *)u8"→11");
-      else                  strncpy  (szAPIName, (const char *)u8"D3D9→11", 32);
+      lstrcatA (szAPIName, (const char *)u8"→11");
     }
 
     lstrcatA ( szAPIName,

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -2008,12 +2008,22 @@ SK_StartupCore (const wchar_t* backend, void* callback)
   //
   if (SK_GetDLLRole () == DLL_ROLE::D3D8)
   {
+    if (SK_IsInjected () && config.apis.translated == SK_RenderAPI::None)
+    {
+      config.compatibility.init_on_separate_thread = false;
+    }
+
     swprintf (wszProxyName, LR"(%s\PlugIns\ThirdParty\dgVoodoo\d3d8.dll)",
                               SK_GetInstallPath ());
   }
 
   else if (SK_GetDLLRole () == DLL_ROLE::DDraw)
   {
+    if (SK_IsInjected () && config.apis.translated == SK_RenderAPI::None)
+    {
+      config.compatibility.init_on_separate_thread = false;
+    }
+
     swprintf (wszProxyName, LR"(%s\PlugIns\ThirdParty\dgVoodoo\ddraw.dll)",
                               SK_GetInstallPath ());
   }

--- a/src/diagnostics/compatibility.cpp
+++ b/src/diagnostics/compatibility.cpp
@@ -324,12 +324,12 @@ SK_Bypass_CRT (LPVOID)
         ) != INVALID_FILE_ATTRIBUTES;
     };
 
-  auto dgVooodoo_Nag = [&](void) ->
+  auto dgVoodoo_Nag = [&](void) ->
     bool
     {
       while (
-        MessageBox (HWND_DESKTOP, L"dgVoodoo is required for Direct3D8 / DirecrtDraw support\r\n\t"
-                                  L"Please install its DLLs to 'Documents\\My Mods\\SpecialK\\PlugIns\\ThidParty\\dgVoodoo'",
+        MessageBox (HWND_DESKTOP, L"dgVoodoo is required for Direct3D 8 / DirectDraw support\r\n\t"
+                                  L"Please install its DLLs to 'Documents\\My Mods\\Special K\\PlugIns\\ThirdParty\\dgVoodoo'",
                                     L"Third-Party Plug-In Required",
                                       MB_ICONSTOP | MB_RETRYCANCEL) == IDRETRY && (! dgVoodoo_Check ())
             ) ;
@@ -738,7 +738,7 @@ SK_Bypass_CRT (LPVOID)
         config.apis.dxgi.d3d12.hook = true;  // D3D8 on D3D12 (not native D3D8)
         config.apis.d3d8.hook       = true;
 
-        if (has_dgvoodoo || dgVooodoo_Nag ())
+        if (has_dgvoodoo || dgVoodoo_Nag ())
         {
           if (nButtonPressed == BUTTON_INSTALL)
           {
@@ -772,7 +772,7 @@ SK_Bypass_CRT (LPVOID)
 
         if (nButtonPressed == BUTTON_INSTALL)
         {
-          if (has_dgvoodoo || dgVooodoo_Nag ())
+          if (has_dgvoodoo || dgVoodoo_Nag ())
           {
             if (SK_IsInjected ())
               SK_Inject_SwitchToRenderWrapperEx (DLL_ROLE::DDraw);

--- a/src/diagnostics/compatibility.cpp
+++ b/src/diagnostics/compatibility.cpp
@@ -328,7 +328,7 @@ SK_Bypass_CRT (LPVOID)
     bool
     {
       while (
-        MessageBox (HWND_DESKTOP, L"dgVoodoo is required for Direct3D 8 / DirectDraw support\r\n\t"
+        MessageBox (HWND_DESKTOP, L"dgVoodoo is required for Direct3D8 / DirectDraw support\r\n\t"
                                   L"Please install its DLLs to 'Documents\\My Mods\\Special K\\PlugIns\\ThirdParty\\dgVoodoo'",
                                     L"Third-Party Plug-In Required",
                                       MB_ICONSTOP | MB_RETRYCANCEL) == IDRETRY && (! dgVoodoo_Check ())

--- a/src/render/d3d9/d3d9.cpp
+++ b/src/render/d3d9/d3d9.cpp
@@ -668,7 +668,7 @@ void
 WINAPI
 SK_HookD3D9 (void)
 {
-  if (config.apis.d3d9.translated)
+  if (config.apis.translated == SK_RenderAPI::D3D9)
     return;
 
   static volatile LONG hooked = FALSE;
@@ -6502,7 +6502,7 @@ HookD3D9 (LPVOID user)
 {
   UNREFERENCED_PARAMETER (user);
 
-  if (config.apis.d3d9.translated || (! config.apis.d3d9.hook))
+  if (config.apis.translated == SK_RenderAPI::D3D9 || (! config.apis.d3d9.hook))
   {
     return 0;
   }
@@ -9973,9 +9973,8 @@ SK_D3D9_QuickHook (void)
 {
   // We don't want to hook this, and we certainly don't want to hook it using
   //   cached addresses!
-  if (    config.apis.d3d9.translated ||
-      (! (config.apis.d3d9.hook       ||
-          config.apis.d3d9ex.hook) ) )
+  if ( (   config.apis.translated == SK_RenderAPI::D3D9       ) ||
+       (! (config.apis.d3d9.hook  || config.apis.d3d9ex.hook) ) )
     return;
 
   if (config.steam.preload_overlay)

--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -6128,7 +6128,7 @@ DXGIFactory_CreateSwapChain_Override (
     {
       if (  pCmdQueue.p    == nullptr &&
             pSwapToRecycle == nullptr &&
-           ppSwapChain     != nullptr /*&& (! config.apis.d3d9.translated)*/ )
+           ppSwapChain     != nullptr /*&& config.apis.translated != SK_RenderAPI::D3D9*/ )
       {
         pSwapToRecycle = *ppSwapChain;
 

--- a/src/render/render_backend.cpp
+++ b/src/render/render_backend.cpp
@@ -1506,10 +1506,11 @@ SK_Render_GetAPIName (SK_RenderAPI api)
   static const
     std::unordered_map <SK_RenderAPI, const wchar_t *>
       api_map {
-        { SK_RenderAPI::D3D11,  L"D3D11" }, { SK_RenderAPI::D3D12,    L"D3D12"  },
-        { SK_RenderAPI::D3D9,   L"D3D9"  }, { SK_RenderAPI::D3D9Ex,   L"D3D9Ex" },
-        { SK_RenderAPI::OpenGL, L"OpenGL"}, { SK_RenderAPI::D3D8,     L"D3D8"   },
-        { SK_RenderAPI::DDraw,  L"DDraw" }, { SK_RenderAPI::Reserved, L"N/A"    }
+        { SK_RenderAPI::D3D11,    L"D3D11"  }, { SK_RenderAPI::D3D12,  L"D3D12"  },
+        { SK_RenderAPI::D3D9,     L"D3D9"   }, { SK_RenderAPI::D3D9Ex, L"D3D9Ex" },
+        { SK_RenderAPI::OpenGL,   L"OpenGL" }, { SK_RenderAPI::D3D8,   L"D3D8"   },
+        { SK_RenderAPI::DDraw,    L"DDraw"  }, { SK_RenderAPI::Glide,  L"Glide"  },
+        { SK_RenderAPI::Reserved, L"N/A"    }
       };
 
   if (api_map.count (api) != 0)


### PR DESCRIPTION
- Updated `SK_dgVoodoo_CheckForInterop (...)` to detect all dgVoodoo DLLs/APIs (D3D9/D3D8/DDraw/Glide) instead of D3D9 only.
- Applied dgVoodoo compatibility settings (`UseFactoryCache=false`, `SkipRedundantModeChanges=true`) for local injection as well.
- Disabled `AsyncInit` for global D3D8/DDraw injection (dgVoodoo Plug-In).
- Disabled dgVoodoo Plug-In if a D3D8/DDraw game is already translated.
- Fixed some typos in `dgVoodoo_Nag (...)`