### PR TITLE
Add more Refresh Rate Factors

### DIFF
--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5381,7 +5381,7 @@ SK_ImGui_ControlPanel (void)
             static std::vector <double> dFractList;
             static int                  iFractSel  = 0;
             static auto                *pLastLabel = command;
-            static auto                 itemWidth  =
+                   auto                 itemWidth  =
               ImGui::CalcTextSize (std::format ("1:1 ({:.10f})", realRefresh).c_str ()).x;
 
             if ( ( std::exchange (pLastLabel,  command)
@@ -5389,9 +5389,6 @@ SK_ImGui_ControlPanel (void)
                  ( std::exchange (lastRefresh, realRefresh)
                                             != realRefresh ) )
             {
-              itemWidth =
-                ImGui::CalcTextSize (std::format ("1:1 ({:.10f})", realRefresh).c_str ()).x;
-
               int idx = 0, denom = 1;
 
               strFractList.clear ();

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5460,7 +5460,7 @@ SK_ImGui_ControlPanel (void)
               {
                 config.render.framerate.present_interval = 1;
 
-                if (target_mag > dRefresh)
+                if (__target_fps > dRefresh)
                 {
                   __SK_LatentSyncSkip = 0;
                   iFractSel           = 0;
@@ -5492,13 +5492,25 @@ SK_ImGui_ControlPanel (void)
 
                 config.render.framerate.present_interval = 0;
 
-                if (maxLatentSyncSkip < 2 && target_mag > dRefresh)
+                if (__target_fps == 0.0f || (maxLatentSyncSkip < 2 && target_mag > dRefresh))
                 {
                   __SK_LatentSyncSkip = 0;
                   iFractSel           = 0;
 
                   SK_GetCommandProcessor ()->ProcessCommandFormatted (
                     "TargetFPS %f", static_cast <float> (dRefresh)
+                  );
+                }
+
+                else if (__target_fps < 0.0f)
+                {
+                  if (maxLatentSyncSkip < 2)
+                  {
+                    __SK_LatentSyncSkip = 0;
+                  }
+
+                  SK_GetCommandProcessor ()->ProcessCommandFormatted (
+                    "TargetFPS %f", target_mag
                   );
                 }
               }

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5539,7 +5539,7 @@ SK_ImGui_ControlPanel (void)
 
                 if (dMultiplier >= 2.0)
                 {
-                  iMode = iFractSel + std::max (maxLatentSyncSkip - 1, 0);
+                  iMode += iFractSel;
                 }
               }
 

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5526,7 +5526,7 @@ SK_ImGui_ControlPanel (void)
               std::string strModeList = strFractList;
               int           iMode     = std::max (maxLatentSyncSkip - 1, 0); // 1:1
 
-              double dMultiplier = std::round (fabs (static_cast <double> (__target_fps) / dRefresh));
+              double dMultiplier = std::round (static_cast <double> (__target_fps) / dRefresh);
 
               if (maxLatentSyncSkip >= 2 && dMultiplier >= 2.0)
               {
@@ -5544,7 +5544,7 @@ SK_ImGui_ControlPanel (void)
               {
                 __SK_LatentSyncSkip = 0;
 
-                dMultiplier = std::round (fabs (dRefresh / static_cast <double> (__target_fps)));
+                dMultiplier = std::round (dRefresh / static_cast <double> (__target_fps));
 
                 if (dMultiplier >= 2.0)
                 {


### PR DESCRIPTION
- Added more Refresh Rate Factors in control panel (`1/2, 1/3, 1/4, 1/5...` instead of `1/2, 1/4, 1/8, 1/16...`).
  - If there are multiple similar factors (30.9, 30.5 ... 30.0), only the lowest one (30.0) will be listed.
- Added Latent Sync 3x mode (currently disabled like the other 2x and 4x modes).
  - Once enabled, Latent Sync scan mode list will be appended with even higher modes when a user selects the current highest mode (selecting 4x adds 5x/6x, selecting 6x adds 7x/8x...).
- The selected factor will be remembered to allow seamless transition between regular and Latent Sync limiters (selecting regular 1/N factor and then checking Latent Sync checkbox will no longer reset FPS limit to 1:1).
![image](https://github.com/SpecialKO/SpecialK/assets/129186721/dae7abb3-3591-43da-9f4e-de7eaf7bda25)
![image](https://github.com/SpecialKO/SpecialK/assets/129186721/a52109f8-9081-40d1-ad40-5521573dc4a8)
