### PR TITLE
Added Adaptive Tearing options and enabled Latent Sync 2x.. modes

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -118,6 +118,16 @@ enum SK_FrametimeMethod
   SK_FrametimeMeasures_NewFrameBegin = 2
 };
 
+enum SK_TearingMode
+{
+  AlwaysOn             = 0,
+  AlwaysOff            = 1,
+  AlwaysOff_LowLatency = 2,
+  AdaptiveOn           = 3,
+  AdaptiveOff          = 4, // Adaptive VSync
+  AppControlled        = SK_NoPreference
+};
+
 struct sk_config_t
 {
   sk_config_t (void)
@@ -729,6 +739,8 @@ struct sk_config_t
       } rescan_;
       int     refresh_denom       =     1;
       int     pin_render_thread   = SK_NoPreference;
+      int     tearing_mode        = SK_TearingMode::AppControlled;
+      bool    turn_vsync_off      = false; // Turns VSync Off in Adaptive VSync mode
       bool    flip_discard        =  true; // Enabled by default (7/6/21)
       bool    flip_sequential     = false;
       bool    disable_flip        = false;
@@ -781,7 +793,7 @@ struct sk_config_t
             }, L"ToggleFCATBars"
           };
         int   scanline_offset      =    -1;
-        int   scanline_resync      =  1000;
+        int   scanline_resync      = 30000;
         float delay_bias           =  0.0f;
         bool  auto_bias            = false;
         float max_auto_bias        =  0.5f;

--- a/include/SpecialK/core.h
+++ b/include/SpecialK/core.h
@@ -106,6 +106,7 @@ bool SK_API_IsDXGIBased      (SK_RenderAPI api);
 bool SK_API_IsGDIBased       (SK_RenderAPI api);
 bool SK_API_IsDirect3D9      (SK_RenderAPI api);
 bool SK_API_IsPlugInBased    (SK_RenderAPI api);
+bool SK_API_IsLayeredOnD3D10 (SK_RenderAPI api);
 bool SK_API_IsLayeredOnD3D11 (SK_RenderAPI api);
 bool SK_API_IsLayeredOnD3D12 (SK_RenderAPI api);
 

--- a/include/SpecialK/framerate.h
+++ b/include/SpecialK/framerate.h
@@ -803,6 +803,8 @@ SK_DWM_GetCompositionTimingInfo       (DWM_TIMING_INFO *pTimingInfo);
 void SK_Framerate_WaitUntilQPC        (LONGLONG llQPC, HANDLE& hTimer);
 void SK_Framerate_EnergyControlPanel  (void);
 
+bool SK_LatentSync_AllowFrameSkip     (void);
+
 void SK_ImGui_DrawGraph_FramePacing   (void);
 void SK_ImGui_DrawFramePercentiles    (void);
 void SK_ImGui_DrawGraph_Latency       (bool predraw);
@@ -830,6 +832,7 @@ extern int  __SK_LatentSyncSkip;
 
 extern float __target_fps;
 extern float __target_fps_bg;
+extern float __target_fps_temp;
 
 extern LONGLONG __SK_LatentSyncPostDelay;
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -574,6 +574,26 @@ SK_ICommandProcessor::ProcessCommandLine (const char* szCommandLine)
               (float)strtof (&cmd_args.c_str ()[2], nullptr);
           }
           /* Assign */
+          else if (     cmd_args.find ('/') != std::string::npos)
+          {
+            if ( cmd_word == "BackgroundFPS" ||
+                 cmd_word == "TargetFPS"     )
+            {
+              int numerator = 1, denominator = 1;
+
+              sscanf (cmd_args.c_str (), "%i/%i", &numerator, &denominator);
+
+              if (denominator != 0)
+              {
+                float_val = static_cast <float> (
+                  ( SK_GetCurrentRenderBackend ()
+                      . getActiveRefreshRate   ()
+                      * numerator
+                  ) / denominator
+                );
+              }
+            }
+          }
           else
             float_val = (float)strtof (cmd_args.c_str (), nullptr);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -916,6 +916,7 @@ struct {
     sk::ParameterInt*     prerender_limit         = nullptr;
     sk::ParameterInt*     present_interval        = nullptr;
     sk::ParameterInt*     sync_interval_clamp     = nullptr;
+    sk::ParameterInt*     tearing_mode            = nullptr;
     sk::ParameterInt*     buffer_count            = nullptr;
     sk::ParameterInt*     max_delta_time          = nullptr;
     sk::ParameterBool*    flip_discard            = nullptr;
@@ -2051,6 +2052,7 @@ auto DeclKeybind =
     ConfigEntry (render.framerate.buffer_count,          L"Number of Backbuffers in the Swapchain",                    dll_ini,         L"Render.FrameRate",      L"BackBufferCount"),
     ConfigEntry (render.framerate.present_interval,      L"Presentation Interval (VSYNC)",                             dll_ini,         L"Render.FrameRate",      L"PresentationInterval"),
     ConfigEntry (render.framerate.sync_interval_clamp,   L"Maximum Sync Interval (Clamp VSYNC)",                       dll_ini,         L"Render.FrameRate",      L"SyncIntervalClamp"),
+    ConfigEntry (render.framerate.tearing_mode,          L"Tearing Mode (Always On/Off or Adaptive)",                  dll_ini,         L"Render.FrameRate",      L"TearingMode"),
     ConfigEntry (render.framerate.prerender_limit,       L"Maximum Frames to Render-Ahead",                            dll_ini,         L"Render.FrameRate",      L"PreRenderLimit"),
     ConfigEntry (render.framerate.sleepless_render,      L"Sleep Free Render Thread",                                  dll_ini,         L"Render.FrameRate",      L"SleeplessRenderThread"),
     ConfigEntry (render.framerate.sleepless_window,      L"Sleep Free Window Thread",                                  dll_ini,         L"Render.FrameRate",      L"SleeplessWindowThread"),
@@ -2071,7 +2073,7 @@ auto DeclKeybind =
                                       allow_latency_wait,L"Allow the game to use a Latency Waitable SwapChain.",       dll_ini,         L"FrameRate.Engine",      L"AllowDXGILatencyWait"),
     ConfigEntry (render.framerate.override_cpu_count,    L"Number of CPU cores to tell the game about",                dll_ini,         L"FrameRate.Engine",      L"OverrideCPUCoreCount"),
     ConfigEntry (render.framerate.latent_sync.offset,    L"Offset in Scanlines from Top of Screen to Steer Tearing",   dll_ini,         L"FrameRate.LatentSync",  L"TearlineOffset"),
-    ConfigEntry (render.framerate.latent_sync.resync,    L"Frequency (in frames) to Resync Timing",                    dll_ini,         L"FrameRate.LatentSync",  L"ResyncFrequency"),
+    ConfigEntry (render.framerate.latent_sync.resync,    L"Frequency (in -frames or milliseconds) to Resync Timing",   dll_ini,         L"FrameRate.LatentSync",  L"ResyncFrequency"),
     ConfigEntry (render.framerate.latent_sync.bias,      L"Controls Distribution of Idle Time Per-Delayed Frame",      dll_ini,         L"FrameRate.LatentSync",  L"DelayBias"),
     ConfigEntry (render.framerate.latent_sync.auto_bias, L"Automatically Sets Delay Bias For Minimum Latency",         dll_ini,         L"FrameRate.LatentSync",  L"AutoBias"),
     ConfigEntry (render.framerate.latent_sync.
@@ -4667,16 +4669,15 @@ auto DeclKeybind =
   {
     if (target_fps.find (L'/') != std::wstring::npos)
     {
-      UINT numerator = 1, denominator = 1;
+      int numerator = 1, denominator = 1;
 
-      swscanf (target_fps.c_str (), L"%i/%i", (INT*)&numerator, (INT*)&denominator);
+      swscanf (target_fps.c_str (), L"%i/%i", &numerator, &denominator);
 
       if (denominator != 0)
       {
-        config.render.framerate.target_fps =
-          static_cast <float> (
-            (rb.windows.device.getDevCaps ().res.refresh * numerator) / denominator
-          );
+        config.render.framerate.target_fps = static_cast <float> (
+          (rb.getActiveRefreshRate () * numerator) / denominator
+        );
       }
     }
 
@@ -4692,16 +4693,15 @@ auto DeclKeybind =
   {
     if (target_fps_bg.find (L'/') != std::wstring::npos)
     {
-      UINT numerator = 1, denominator = 1;
+      int numerator = 1, denominator = 1;
 
-      swscanf (target_fps_bg.c_str (), L"%i/%i", (INT*)&numerator, (INT*)&denominator);
+      swscanf (target_fps_bg.c_str (), L"%i/%i", &numerator, &denominator);
 
       if (denominator != 0)
       {
-        config.render.framerate.target_fps_bg =
-          static_cast <float> (
-            (rb.windows.device.getDevCaps ().res.refresh * numerator) / denominator
-          );
+        config.render.framerate.target_fps_bg = static_cast <float> (
+          (rb.getActiveRefreshRate () * numerator) / denominator
+        );
       }
     }
 
@@ -4815,6 +4815,7 @@ auto DeclKeybind =
   render.framerate.prerender_limit->load     (config.render.framerate.pre_render_limit);
   render.framerate.present_interval->load    (config.render.framerate.present_interval);
   render.framerate.sync_interval_clamp->load (config.render.framerate.sync_interval_clamp);
+  render.framerate.tearing_mode->load        (config.render.framerate.tearing_mode);
 
   if (render.framerate.refresh_rate)
   {
@@ -7085,6 +7086,7 @@ SK_SaveConfig ( std::wstring name,
 
     render.framerate.present_interval->store      (config.render.framerate.present_interval);
     render.framerate.sync_interval_clamp->store   (config.render.framerate.sync_interval_clamp);
+    render.framerate.tearing_mode->store          (config.render.framerate.tearing_mode);
     render.framerate.enforcement_policy->store    (config.render.framerate.enforcement_policy);
     render.framerate.enable_etw_tracing->store    (config.render.framerate.enable_etw_tracing);
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -5139,6 +5139,21 @@ SK_API_IsDXGIBased (SK_RenderAPI api)
 }
 
 bool
+SK_API_IsLayeredOnD3D10 (SK_RenderAPI api)
+{
+  switch (api)
+  {
+    case SK_RenderAPI::D3D10:
+      return true;
+    default:
+      return
+        ( static_cast <UINT> (api) &
+          static_cast <UINT> (SK_RenderAPI::D3D10) )
+       == static_cast <UINT> (SK_RenderAPI::D3D10);
+  }
+}
+
+bool
 SK_API_IsLayeredOnD3D11 (SK_RenderAPI api)
 {
   switch (api)

--- a/src/render/d3d9/d3d9.cpp
+++ b/src/render/d3d9/d3d9.cpp
@@ -1397,9 +1397,23 @@ SK_D3D9_SetFPSTarget ( D3DPRESENT_PARAMETERS* pPresentationParameters,
         }
       };
 
-    if (       config.render.framerate.present_interval != SK_NoPreference &&
+    int presentationInterval =
+      config.render.framerate.present_interval;
+
+    // Latent VSync...
+    if  ( ( config.render.framerate.present_interval == 0 &&
+            config.render.framerate.target_fps > 0.0f      ) &&
+          ( config.render.framerate.tearing_mode ==
+              SK_TearingMode::AlwaysOff                   ||
+            config.render.framerate.tearing_mode ==
+              SK_TearingMode::AlwaysOff_LowLatency         ) )
+    {
+      presentationInterval = 1;
+    }
+
+    if (                           presentationInterval != SK_NoPreference &&
          (! _SK_D3D9_IsPresentIntervalEquivalent (
-               config.render.framerate.present_interval,
+                                   presentationInterval,
           pPresentationParameters->PresentationInterval) ) )
     {
       SK_LOGi0 (
@@ -1407,24 +1421,24 @@ SK_D3D9_SetFPSTarget ( D3DPRESENT_PARAMETERS* pPresentationParameters,
 
         SK_D3D9_GetNominalPresentInterval (
           pPresentationParameters->PresentationInterval
-        ),     config.render.framerate.present_interval
+        ),                         presentationInterval
       );
 
-      if (     config.render.framerate.present_interval == 0)
+      if (                       presentationInterval == 0)
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_IMMEDIATE;
-      else if (config.render.framerate.present_interval == 1)
+      else if (                  presentationInterval == 1)
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_ONE;
-      else if (config.render.framerate.present_interval == 2)
+      else if (                  presentationInterval == 2)
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_TWO;
-      else if (config.render.framerate.present_interval == 3)
+      else if (                  presentationInterval == 3)
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_THREE;
-      else if (config.render.framerate.present_interval == 4)
+      else if (                  presentationInterval == 4)
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_FOUR;
       else
       {
         SK_LOGi0 (
           L"Invalid Present Interval: %d Requested; defaulting to 1:1 Refresh",
-            config.render.framerate.present_interval );
+                                 presentationInterval );
 
         pPresentationParameters->PresentationInterval = D3DPRESENT_INTERVAL_ONE;
       }

--- a/src/render/dxgi/dxgi.cpp
+++ b/src/render/dxgi/dxgi.cpp
@@ -3325,6 +3325,26 @@ SK_DXGI_PresentBase ( IDXGISwapChain         *This,
     int interval =
       config.render.framerate.present_interval;
 
+    if (config.render.framerate.target_fps > 0.0f)
+    {
+      // Adaptive VSync
+      if  ( config.render.framerate.present_interval > 0 &&
+            config.render.framerate.turn_vsync_off       &&
+            config.render.framerate.tearing_mode ==
+              SK_TearingMode::AdaptiveOff                )
+      {
+        interval = 0;
+      }
+
+      // Latent VSync...
+      else if ( config.render.framerate.present_interval == 0 &&
+               !config.render.dxgi.allow_tearing              &&
+                rb.isTrueFullscreen ()                        )
+      {
+        interval = 1;
+      }
+    }
+
     // Fix flags for compliance in broken games
     //
     if (SK_DXGI_IsFlipModelSwapChain (desc))


### PR DESCRIPTION
- Added new tearing modes for regular V-Sync:
  - Always Off (Low Latency): temporarily lowers FPS limit if Render Latency exceeds 1 frame.
  - Adaptive V-Sync: temporarily turns V-Sync Off (without enabling Latent Sync) if FPS is unstable or Render Latency exceeds 1 frame.

- Added new tearing modes for Latent Sync:
  - Always Off (Low Latency): temporarily lowers FPS limit if Render Latency exceeds 1 frame.
  - Adaptive (Prefer On): only disables tearing if FPS is unstable.
  - Adaptive (Prefer Off): only enables tearing if FPS is unstable or Render Latency exceeds 1 frame.

- Made Latent Sync non-tearing modes functional in D3D9 / FSE games by forcing Presentation Interval 1.

- Reset frame limiter when V-Sync gets stuck at high variation or ±0.0 ms input latency (still experimental and does not yet apply to the regular "Always Off" tearing mode).

- Revamped the Auto Bias section:
  - Display actual Delay Bias value when Auto Bias is enabled (updates every 200 ms).
  - Remember last selected Target Input Latency value when switching between millisecond / percentage modes.
  - Hidden Maximum Bias slider if Target Input Latency is in percentage mode (it will only take effect in millisecond mode).

- Refactored and enabled Latent Sync 2x.. modes.

- Restricted 2x.. Scan Mode selection to 5 entries after enabling 4x mode or higher:
  - `1/x  1:1  (2x)  3x   4x`
  - `1/x  1:1   2x   3x  (4x)  5x   6x`
  - `1/x  1:1   4x   5x  (6x)  7x   8x`
  - `1/x  1:1   6x   7x  (8x)  9x  10x` ...

- Re-enabled Buffer Count and Max Device Latency settings for OpenGL-IK and NVIDIA's OpenGL / Vulkan -> D3D11 interop:
  - They do work even in non-direct D3D11 and can be useful for 2x.. modes (e.g., Buffer Count of 4+ allows to render above refresh rate with Tearing Off).

- Added ability to specify `TargetFPS` / `BackgroundFPS` macros as refresh rate factors:
```ini
[Macro.TargetFPS]
Ctrl+Shift+1=TargetFPS 1/1
Ctrl+Shift+2=TargetFPS 1/2
Ctrl+Shift+3=TargetFPS 1/3
Ctrl+Shift+4=TargetFPS 2/1
Ctrl+Shift+5=TargetFPS 3/1

[Macro.BackgroundFPS]
Ctrl+Shift+6=BackgroundFPS 1/1
Ctrl+Shift+7=BackgroundFPS 1/2
Ctrl+Shift+8=BackgroundFPS 1/3
```

- Always show Visualize Tearlines checkbox:
  - Fixes an issue of users not being able to hide FCAT bars after disabling tearing while tearline visualizer was still on.
  - FCAT bars are disabled automatically after switching from Latent Sync to another mode.

- Added ability to specify Resync Rate in seconds (30 seconds is the new default).

- Updated Delay Bias tooltip (Adaptive Sync option is obsolete).

![image](https://github.com/user-attachments/assets/4b433bcd-5a1f-49a3-a397-1775b0c46a80)
![image](https://github.com/user-attachments/assets/8e1e42e1-d99b-40f4-9520-0642902acee0)
![image](https://github.com/user-attachments/assets/7b85250c-0fe6-47bc-93c1-2d889389baeb)
