### PR TITLE
Update Active API if its name is empty

### DIFF
--- a/src/render/render_backend.cpp
+++ b/src/render/render_backend.cpp
@@ -1558,7 +1558,7 @@ SK_RenderBackend_V2::updateActiveAPI (SK_RenderAPI _api)
   static SK_RenderAPI LastKnownAPI =
          SK_RenderAPI::Reserved;
 
-  if (_api != SK_RenderAPI::Reserved)
+  if (_api != SK_RenderAPI::Reserved && wcslen (name))
   {
     LastKnownAPI = _api;
                  return;


### PR DESCRIPTION
- Fixed empty Active Render API name that occasionally appeared after a delayed injection.

![image](https://github.com/SpecialKO/SpecialK/assets/129186721/5c27c032-a203-4c1e-86d3-3d0e19905379)
