### PR TITLE
Improved DLSS indicator

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -289,10 +289,11 @@ struct sk_config_t
 
 
   struct dlss_osd_s {
-    bool   show           = false;
-    bool   show_quality   = true;
-    bool   show_fg        = true;
-    bool   show_preset    = false;
+    bool   show            = false;
+    bool   show_output_res = false;
+    bool   show_quality    = true;
+    bool   show_fg         = true;
+    bool   show_preset     = false;
 
     struct keybinds_s {
       BYTE toggle [4]     = { VK_MENU, VK_SHIFT, 'D', 0 };

--- a/include/SpecialK/render/ngx/ngx_dlss.h
+++ b/include/SpecialK/render/ngx/ngx_dlss.h
@@ -29,7 +29,7 @@ bool                 SK_NGX_IsUsingDLSS_D     (void);
 bool                 SK_NGX_IsUsingDLSS_G     (void);
 void                 SK_NGX_DLSS_CreateFeatureOverrideParams (NVSDK_NGX_Parameter *InParameters);
 void                 SK_NGX_DLSS_ControlPanel (void);
-void                 SK_NGX_DLSS_GetInternalResolution    (int& x, int& y);
+void                 SK_NGX_DLSS_GetResolution            (int& x, int& y, int& out_x, int& out_y);
 const char*          SK_NGX_DLSS_GetCurrentPerfQualityStr (void);
 const char*          SK_NGX_DLSS_GetCurrentPresetStr      (void);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -508,6 +508,7 @@ struct {
 
   struct {
     sk::ParameterBool*    show                    = nullptr;
+    sk::ParameterBool*    show_output_res         = nullptr;
     sk::ParameterBool*    show_quality            = nullptr;
     sk::ParameterBool*    show_preset             = nullptr;
     sk::ParameterBool*    show_fg                 = nullptr;
@@ -1498,6 +1499,7 @@ auto DeclKeybind =
     ConfigEntry (monitoring.pagefile.interval,           L"Pagefile Monitoring Interval (seconds)",                    osd_ini,         L"Monitor.Pagefile",      L"Interval"),
 
     ConfigEntry (monitoring.dlss.show,                   L"Show DLSS Resolution Information",                          osd_ini,         L"Monitor.DLSS",          L"Show"),
+    ConfigEntry (monitoring.dlss.show_output_res,        L"Print DLSS Output Resolution",                              osd_ini,         L"Monitor.DLSS",          L"ShowOutputResolution"),
     ConfigEntry (monitoring.dlss.show_quality,           L"Print DLSS Quality Level",                                  osd_ini,         L"Monitor.DLSS",          L"ShowQuality"),
     ConfigEntry (monitoring.dlss.show_preset,            L"Print DLSS Preset",                                         osd_ini,         L"Monitor.DLSS",          L"ShowPreset"),
     ConfigEntry (monitoring.dlss.show_fg,                L"Print DLSS Frame Generation Status",                        osd_ini,         L"Monitor.DLSS",          L"ShowFrameGeneration"),
@@ -3765,10 +3767,11 @@ auto DeclKeybind =
   config.pagefile.interval = std::clamp (config.pagefile.interval, 0.125f, 2.5f);
   config.io.interval       = std::clamp (config.io.interval,       0.125f, 2.5f);
 
-  monitoring.dlss.show->load         (config.dlss.show);
-  monitoring.dlss.show_quality->load (config.dlss.show_quality);
-  monitoring.dlss.show_preset->load  (config.dlss.show_preset);
-  monitoring.dlss.show_fg->load      (config.dlss.show_fg);
+  monitoring.dlss.show->load            (config.dlss.show);
+  monitoring.dlss.show_output_res->load (config.dlss.show_output_res);
+  monitoring.dlss.show_quality->load    (config.dlss.show_quality);
+  monitoring.dlss.show_preset->load     (config.dlss.show_preset);
+  monitoring.dlss.show_fg->load         (config.dlss.show_fg);
 
   monitoring.title.show->load (config.title.show);
   monitoring.time.show->load  (config.time.show);
@@ -5638,6 +5641,7 @@ SK_SaveConfig ( std::wstring name,
   monitoring.pagefile.interval->store         (config.pagefile.interval);
 
   monitoring.dlss.show->store                 (config.dlss.show);
+  monitoring.dlss.show_output_res->store      (config.dlss.show_output_res);
   monitoring.dlss.show_quality->store         (config.dlss.show_quality);
   monitoring.dlss.show_preset->store          (config.dlss.show_preset);
   monitoring.dlss.show_fg->store              (config.dlss.show_fg);

--- a/src/control_panel/cfg_osd.cpp
+++ b/src/control_panel/cfg_osd.cpp
@@ -171,6 +171,31 @@ SK::ControlPanel::OSD::Draw (void)
 
       // New line
 
+      if (sk::NVAPI::nv_hardware)
+      {
+        ImGui::Checkbox ("DLSS", &config.dlss.show);
+        if (config.dlss.show)
+        {
+          ImGui::SameLine   ();
+          ImGui::BeginGroup ();
+          ImGui::TreePush ("");
+
+          ImGui::Checkbox   ("Output Resolution ", &config.dlss.show_output_res);
+          ImGui::SameLine   ();
+          ImGui::Checkbox   ("Quality Level ",     &config.dlss.show_quality);
+          ImGui::SameLine   ();
+          ImGui::Checkbox   ("Preset ",            &config.dlss.show_preset);
+          ImGui::SameLine   ();
+          ImGui::Checkbox   ("Frame Generation",   &config.dlss.show_fg);
+
+
+          ImGui::TreePop  (  );
+          ImGui::EndGroup   ();
+        }
+      }
+
+      // New line
+
       ImGui::Checkbox   ("GPU Stats",    &config.gpu.show);
       ImGui::SameLine   ();
       ImGui::BeginGroup ();
@@ -193,25 +218,6 @@ SK::ControlPanel::OSD::Draw (void)
       }
       ImGui::EndGroup   ();
 
-      if (! config.gpu.show)
-        ImGui::SameLine ();
-
-      ImGui::BeginGroup ();
-      if (sk::NVAPI::nv_hardware)
-      {
-        ImGui::Checkbox ("DLSS", &config.dlss.show);
-        if (config.dlss.show)
-        {
-          ImGui::TreePush ("");
-          ImGui::Checkbox (" Current Quality Level",   &config.dlss.show_quality);
-          ImGui::SameLine ();
-          ImGui::Checkbox (" Current Preset",          &config.dlss.show_preset);
-          ImGui::SameLine ();
-          ImGui::Checkbox (" Frame Generation",        &config.dlss.show_fg);
-          ImGui::TreePop  (  );
-        }
-      }
-      ImGui::EndGroup   ();
       ImGui::TreePop    ();
     }
 

--- a/src/osd/text.cpp
+++ b/src/osd/text.cpp
@@ -1007,6 +1007,43 @@ SK_DrawOSD (void)
 
   _DrawFrameCountIf (! (config.fps.show || config.fps.compact));
 
+  if (config.dlss.show && (SK_NGX_IsUsingDLSS () || SK_NGX_IsUsingDLSS_G ()))
+  {
+    int x     = 0,
+        y     = 0,
+        out_x = 0,
+        out_y = 0;
+
+    SK_NGX_DLSS_GetResolution (x, y, out_x, out_y);
+
+    if (x + y != 0)
+    {
+      OSD_DLSS_PRINTF "%*hsDLSS   :  %dx%d", left_padding, pad_str, x, y OSD_END
+
+      if (config.dlss.show_output_res && out_x + out_y != 0)
+      {
+        OSD_DLSS_PRINTF " -> %dx%d", out_x, out_y OSD_END
+      }
+
+      if (config.dlss.show_quality)
+      {
+        OSD_DLSS_PRINTF " %hs", SK_NGX_DLSS_GetCurrentPerfQualityStr () OSD_END
+      }
+
+      if (config.dlss.show_preset)
+      {
+        OSD_DLSS_PRINTF " [%hs]", SK_NGX_DLSS_GetCurrentPresetStr () OSD_END
+      }
+
+      if (config.dlss.show_fg && SK_NGX_IsUsingDLSS_G ())
+      {
+        OSD_DLSS_PRINTF " [FG]" OSD_END
+      }
+
+      OSD_DLSS_PRINTF "\n" OSD_END
+    }
+  }
+
   // Poll GPU stats...
   if (config.gpu.show)
     SK_PollGPU ();
@@ -1576,47 +1613,6 @@ SK_DrawOSD (void)
     OSD_END
 
     OSD_M_PRINTF "\n" OSD_END
-  }
-
-  if (config.dlss.show && (SK_NGX_IsUsingDLSS () || SK_NGX_IsUsingDLSS_G ()))
-  {
-    int x = 0,
-        y = 0;
-
-    SK_NGX_DLSS_GetInternalResolution (x,y);
-
-    if (x + y != 0)
-    {
-      OSD_DLSS_PRINTF "DLSS Resolution: %dx%d", x,y OSD_END
-
-      if (config.dlss.show_fg && SK_NGX_IsUsingDLSS_G ())
-      {
-        OSD_DLSS_PRINTF " [FG]" OSD_END
-      }
-
-      OSD_DLSS_PRINTF "\n" OSD_END
-
-      if (config.dlss.show_preset || config.dlss.show_quality)
-      {
-        if (config.dlss.show_preset && config.dlss.show_quality)
-        {
-          OSD_DLSS_PRINTF "DLSS Quality:    %hs [%hs]\n", SK_NGX_DLSS_GetCurrentPerfQualityStr (),
-                                                          SK_NGX_DLSS_GetCurrentPresetStr      () OSD_END
-        }
-
-        else if (config.dlss.show_preset)
-        {
-          OSD_DLSS_PRINTF "DLSS Preset:     %hs\n", SK_NGX_DLSS_GetCurrentPresetStr () OSD_END
-        }
-
-        else if (config.dlss.show_quality)
-        {
-          OSD_DLSS_PRINTF "DLSS Quality:    %hs\n", SK_NGX_DLSS_GetCurrentPerfQualityStr () OSD_END
-        }
-      }
-
-      OSD_DLSS_PRINTF "\n" OSD_END
-    }
   }
 
   static auto& disk_stats = SK_WMI_DiskStats.get ();

--- a/src/render/ngx/ngx.cpp
+++ b/src/render/ngx/ngx.cpp
@@ -1168,7 +1168,7 @@ SK_NGX_DLSS_GetCurrentPresetStr (void)
 }
 
 void
-SK_NGX_DLSS_GetInternalResolution (int& x, int& y)
+SK_NGX_DLSS_GetResolution (int& x, int& y, int& out_x, int& out_y)
 { 
   if (NVSDK_NGX_Parameter_GetUI_Original == nullptr)
   {
@@ -1223,8 +1223,10 @@ SK_NGX_DLSS_GetInternalResolution (int& x, int& y)
     if (height == 0) height = res_height;
   }
 
-  x = width;
-  y = height;
+  x     = width;
+  y     = height;
+  out_x = out_width;
+  out_y = out_height;
 }
 
 void


### PR DESCRIPTION
Made various changes to the DLSS indicator.

* Added output resolution
* Merged all the options into a single line
* Moved its placement in the OSD to above the GPU stats
* * Also added necessary padding etc to fit its new placement
* Changed the relevant control panel UI elements to reflect the changes

![image](https://github.com/SpecialKO/SpecialK/assets/10578344/c42a4528-fa72-476c-a0e1-a0bfae52f579)
