### PR TITLE
Console Y pos should be relative to the OSD height

### DIFF
--- a/include/SpecialK/osd/text.h
+++ b/include/SpecialK/osd/text.h
@@ -66,6 +66,7 @@ public:
   void  resize    (float incr)                 noexcept;
   void  setScale  (float scale)                noexcept;
   float getScale  (void)                       noexcept;
+  float getExtent (void)                       noexcept;
 
   void  move      (float  x_off, float  y_off) noexcept;
   void  setPos    (float  x,     float  y)     noexcept;

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * This file is part of Special K.
  *
  * Special K is free software : you can redistribute it
@@ -98,7 +98,26 @@ SK_Console::Draw (void)
                              getTextOverlay ("SpecialK Console");
 
     if (pOverlay != nullptr)
+    {
+      // Use the height of the OSD for relative placement
+      if (config.osd.show &&
+       ! (config.osd.pos_x < 0 || config.osd.pos_y < 0)) // Not when right-aligned or bottom-aligned
+      {
+        SK_TextOverlay* pOverlayOSD =
+          SK_TextOverlayManager::getInstance    ()->
+                                 getTextOverlay ("Special K");
+
+        if (pOverlayOSD != nullptr)
+        {
+          const float y = pOverlayOSD->getExtent ( );
+
+          pOverlay->setPos (2.0f, y);
+        }
+      }
+
+      else
         pOverlay->setPos (2.0f, 0.0f);
+    }
 
     SK_DrawExternalOSD ("SpecialK Console", output);
 

--- a/src/osd/text.cpp
+++ b/src/osd/text.cpp
@@ -2182,6 +2182,12 @@ SK_TextOverlay::getScale (void) noexcept
   return font_.scale;
 }
 
+float
+SK_TextOverlay::getExtent (void) noexcept
+{
+  return data_.extent;
+}
+
 void
 SK_TextOverlay::resize (float incr) noexcept
 {


### PR DESCRIPTION
Since the migration from CEGUI to ImGui, the OSD "overlays" are not all rendered as part of `drawAllOverlays`, and the main OSD overlay and command console overlay are each drawn entirely separately through their individual `draw()` calls as part of `SK_DrawOSD()` and `SK_DrawConsole()` .

This means the position of neither is related to one another, as their height (`data_.extent`) is not shared or carried over from one to the other, and both can end up being rendered at the same position as a result.

This commit adds a new `getExtent()` function that `SK_DrawConsole()` uses to retrieve the height of the main OSD overlay, and uses that as its Y position (if neither bottom-aligned or right-aligned).