### PR TITLE
Corrected VK_PRINT to VK_SNAPSHOT

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -547,7 +547,7 @@ struct sk_config_t
          clipboard_only_keybind = {
       SK_Keybind {
         "Copy a Screenshot to Clipboard Only", L"",
-         false, false, false, VK_PRINT
+         false, false, false, VK_SNAPSHOT
       }, L"ClipboardOnly"
     };
 
@@ -555,7 +555,7 @@ struct sk_config_t
          snipping_keybind = {
       SK_Keybind {
         "Snip a Screenshot to the Clipboard", L"",
-         true, false, false, VK_PRINT
+         true, false, false, VK_SNAPSHOT
       }, L"Snipping"
     };
   } screenshots;

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -3125,7 +3125,7 @@ SK_ImGui_User_NewFrame (void)
     io.KeyMap [ImGuiKey_Enter]          = VK_RETURN;
     io.KeyMap [ImGuiKey_Escape]         = VK_ESCAPE;
     io.KeyMap [ImGuiKey_ScrollLock]     = VK_SCROLL;
-    io.KeyMap [ImGuiKey_PrintScreen]    = VK_PRINT;
+    io.KeyMap [ImGuiKey_PrintScreen]    = VK_SNAPSHOT;
     io.KeyMap [ImGuiKey_Pause]          = VK_PAUSE;
     io.KeyMap [ImGuiKey_CapsLock]       = VK_CAPITAL;
     io.KeyMap [ImGuiKey_NumLock]        = VK_NUMLOCK;


### PR DESCRIPTION
`VK_SNAPSHOT` refers to the physical Print Screen key.
`VK_PRINT` refers to some now obsolete key that was probably mapped to a print action.