### PR TITLE
Fix hue shifting when using SDR Gamma Boost

### DIFF
--- a/resource/shaders/HDR/basic_hdr_shader_ps.hlsl
+++ b/resource/shaders/HDR/basic_hdr_shader_ps.hlsl
@@ -462,7 +462,7 @@ main (PS_INPUT input) : SV_TARGET
     if (input.color.y != 1.0f)
     {
       float fLuma = Luminance(hdr_color.rgb);
-      float fLumaWithGamma = sign(fLuma) * pow(abs(fLuma), input.color.y);
+      float fLumaWithGamma = pow(fLuma, input.color.y);
       hdr_color.rgb = hdr_color.rgb * (fLumaWithGamma / fLuma);
     }
   }

--- a/resource/shaders/HDR/basic_hdr_shader_ps.hlsl
+++ b/resource/shaders/HDR/basic_hdr_shader_ps.hlsl
@@ -461,9 +461,9 @@ main (PS_INPUT input) : SV_TARGET
   {
     if (input.color.y != 1.0f)
     {
-      hdr_color.rgb = sign (hdr_color.rgb) *
-                  pow (abs (hdr_color.rgb),
-                          input.color.yyy);
+      float fLuma = Luminance(hdr_color.rgb);
+      float fLumaWithGamma = sign(fLuma) * pow(abs(fLuma), input.color.y);
+      hdr_color.rgb = hdr_color.rgb * (fLumaWithGamma / fLuma);
     }
   }
 


### PR DESCRIPTION
In the current implementation, the hue shifts when using SDR Gamma Boost (it changes both when lowering or raising SDR Gamma Boost).

This commit fixes the behavior to be based on Luminance instead.