### PR TITLE
Backup input thread GetKeyboardState optimization fixes

### DIFF
--- a/include/SpecialK/input/input.h
+++ b/include/SpecialK/input/input.h
@@ -1391,6 +1391,7 @@ bool SK_ImGui_CursorWarpingCooledDown           (void);
 void SK_ImGui_UpdateLastCursorWarpTime          (void);
 
 extern bool SK_ImGui_IsHWCursorVisible;
+extern bool SK_ImGui_BackupInput_DisableGetKeyboardStateOptimization;
 
 enum SK_InputEnablement {
   Enabled              = 0,

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -3472,8 +3472,9 @@ SK_ImGui_BackupInputThread (LPVOID)
     { __SK_DLL_TeardownEvent,
         SK_ImGui_SignalBackupInputThread };
 
-  DWORD  dwWaitState  = WAIT_TIMEOUT;
-  while (dwWaitState != WAIT_OBJECT_0)
+  static BYTE  last_keyboard_state [512] = {};
+  DWORD        dwWaitState  = WAIT_TIMEOUT;
+  while       (dwWaitState != WAIT_OBJECT_0)
   {
     dwWaitState = 
       WaitForMultipleObjects (2, hEvents, FALSE, SK_ImGui_Active () ? 3 : 100);
@@ -3485,7 +3486,6 @@ SK_ImGui_BackupInputThread (LPVOID)
          (dwWaitState == (WAIT_OBJECT_0 + 1)))
     {
       static BYTE       keyboard_state [512] = {};
-      static BYTE  last_keyboard_state [512] = {};
       GetKeyboardState (keyboard_state);
 
       static            LASTINPUTINFO

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -3472,7 +3472,7 @@ SK_ImGui_BackupInputThread (LPVOID)
     { __SK_DLL_TeardownEvent,
         SK_ImGui_SignalBackupInputThread };
 
-  static BYTE  last_keyboard_state [512] = {};
+  static BYTE  last_keyboard_state [256] = {};
   DWORD        dwWaitState  = WAIT_TIMEOUT;
   while       (dwWaitState != WAIT_OBJECT_0)
   {
@@ -3485,7 +3485,7 @@ SK_ImGui_BackupInputThread (LPVOID)
     if (ReadULongAcquire (&SK_ImGui_LastKeyboardProcMessageTime) < SK::ControlPanel::current_time - 500UL &&
          (dwWaitState == (WAIT_OBJECT_0 + 1)))
     {
-      static BYTE       keyboard_state [512] = {};
+      static BYTE       keyboard_state [256] = {};
       GetKeyboardState (keyboard_state);
 
       static            LASTINPUTINFO
@@ -3499,7 +3499,7 @@ SK_ImGui_BackupInputThread (LPVOID)
         dwLastInput =
           std::max (dwLastInput, lii.dwTime);
 
-        if (memcmp (keyboard_state, last_keyboard_state, sizeof (BYTE) * 512) != 0)
+        if (memcmp (keyboard_state, last_keyboard_state, sizeof (BYTE) * 256) != 0)
         {
           auto& io =
             ImGui::GetIO ();
@@ -3507,7 +3507,7 @@ SK_ImGui_BackupInputThread (LPVOID)
           bool    last_keys              [256] = {};
           memcpy (last_keys, io.KeysDown, 256);
           memcpy (last_keyboard_state,
-                       keyboard_state, sizeof (BYTE) * 512);
+                       keyboard_state, sizeof (BYTE) * 256);
 
           for (UINT i = 7 ; i < 255 ; ++i)
           {

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -3485,9 +3485,6 @@ SK_ImGui_BackupInputThread (LPVOID)
     if (ReadULongAcquire (&SK_ImGui_LastKeyboardProcMessageTime) < SK::ControlPanel::current_time - 500UL &&
          (dwWaitState == (WAIT_OBJECT_0 + 1)))
     {
-      static BYTE       keyboard_state [256] = {};
-      GetKeyboardState (keyboard_state);
-
       static            LASTINPUTINFO
         lii = { sizeof (LASTINPUTINFO), 1 };
 
@@ -3498,6 +3495,9 @@ SK_ImGui_BackupInputThread (LPVOID)
       {
         dwLastInput =
           std::max (dwLastInput, lii.dwTime);
+
+        static BYTE       keyboard_state [256] = {};
+        GetKeyboardState (keyboard_state);
 
         if (memcmp (keyboard_state, last_keyboard_state, sizeof (BYTE) * 256) != 0)
         {

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -3456,11 +3456,12 @@ SK_ImGui_UpdateClassCursor (void)
       game_window.game_cursor = game_window.real_cursor;
 }
 
-                HANDLE SK_ImGui_SignalBackupInputThread = 0;
-                bool   SK_ImGui_IsHWCursorVisible       = false;
-extern          BOOL  SK_ImGui_NewInput;
-extern volatile DWORD SK_ImGui_LastKeyboardProcMessageTime;
-extern volatile DWORD SK_ImGui_LastMouseProcMessageTime;
+                HANDLE SK_ImGui_SignalBackupInputThread                           = 0;
+                bool   SK_ImGui_IsHWCursorVisible                                 = false;
+                bool   SK_ImGui_BackupInput_DisableGetKeyboardStateOptimization = false;
+extern          BOOL   SK_ImGui_NewInput;
+extern volatile DWORD  SK_ImGui_LastKeyboardProcMessageTime;
+extern volatile DWORD  SK_ImGui_LastMouseProcMessageTime;
 
 DWORD
 WINAPI
@@ -3496,18 +3497,24 @@ SK_ImGui_BackupInputThread (LPVOID)
         dwLastInput =
           std::max (dwLastInput, lii.dwTime);
 
-        static BYTE       keyboard_state [256] = {};
-        GetKeyboardState (keyboard_state);
+        bool bProcessInput = true;
+        if (!SK_ImGui_BackupInput_DisableGetKeyboardStateOptimization) {
+          static BYTE       keyboard_state [256] = {};
+          GetKeyboardState (keyboard_state);
 
-        if (memcmp (keyboard_state, last_keyboard_state, sizeof (BYTE) * 256) != 0)
+          bProcessInput = memcmp (keyboard_state, last_keyboard_state, sizeof (BYTE) * 256) != 0;
+
+          memcpy (last_keyboard_state,
+                  keyboard_state, sizeof (BYTE) * 256);
+        }
+
+        if (bProcessInput)
         {
           auto& io =
             ImGui::GetIO ();
 
           bool    last_keys              [256] = {};
           memcpy (last_keys, io.KeysDown, 256);
-          memcpy (last_keyboard_state,
-                       keyboard_state, sizeof (BYTE) * 256);
 
           for (UINT i = 7 ; i < 255 ; ++i)
           {

--- a/src/input/raw_input.cpp
+++ b/src/input/raw_input.cpp
@@ -515,18 +515,26 @@ RegisterRawInputDevices_Detour (
          (pDevices [i].usUsage     ==  HID_USAGE_GENERIC_KEYBOARD ||
           match_any_in_page))
       {
-        if (config.input.keyboard.prevent_no_legacy)
+        if (! match_any_in_page) // This only works for Mouse and Keyboard Usages
         {
-          if (! match_any_in_page) // This only works for Mouse and Keyboard Usages
+          if (pDevices [i].dwFlags & RIDEV_NOLEGACY)
           {
-            if (pDevices [i].dwFlags & RIDEV_NOLEGACY)
+            if (config.input.keyboard.prevent_no_legacy)
             {
               SK_LOGi0 (
                 L"Game tried to register a keyboard with RIDEV_NOLEGACY flag, but "
                 L"we are ignoring it..."
               );
+
+              pDevices [i].dwFlags &= ~RIDEV_NOLEGACY;
+            } else {
+              SK_LOGi0 (
+                L"Game has registered a keyboard with the RIDEV_NOLEGACY flag. "
+                L"Backup input GetKeyboardState optimization will be disabled."
+              );
+
+              SK_ImGui_BackupInput_DisableGetKeyboardStateOptimization = true;
             }
-            pDevices [i].dwFlags     &= ~RIDEV_NOLEGACY;
           }
         }
 

--- a/src/input/winhook_input.cpp
+++ b/src/input/winhook_input.cpp
@@ -817,8 +817,21 @@ SetWindowsHookExA_Detour (
 
     if (idHook == WH_KEYBOARD_LL && hmod == SK_GetModuleHandleW (nullptr))
     {
-      if (PathFileExistsW (L"NoLLKeyboardHooks"))
+      if (PathFileExistsW (L"NoLLKeyboardHooks")) {
+        SK_LOGi0 (
+          L"Game tried to register a low-level keyboard hook, but "
+          L"we are ignoring it..."
+        );
+
         return 0;
+      } else {
+        SK_LOGi0 (
+          L"Game has registered a low-level keyboard hook. "
+          L"Backup input GetKeyboardState optimization will be disabled."
+        );
+
+        SK_ImGui_BackupInput_DisableGetKeyboardStateOptimization = true;
+      }
     }
   }
 


### PR DESCRIPTION
Replaces PR https://github.com/SpecialKO/SpecialK/pull/285.

This PR fixes various issues with the optimization in backup input thread.
The most notable change for users is fixing the inability to open the SpecialK overlay in some games, by disabling the optimization when the game uses a RawInput keyboard with `RIDEV_NOLEGACY` flag or a low-level keyboard hook, which may cause `GetKeyboardState` to not update.

I am not sure whether the low-level keyboard hook disable is required, but the RawInput part was needed for Resident Evil: Village.

However FWIW, as I already mentioned, I am not sure whether the call to `GetKeyboardState` from background thread without message queue processing is compliant with [docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getkeyboardstate#remarks), though it seems to work. :)