### PR TITLE
Added more options to customize Low Latency and Adaptive V-Sync tearing modes

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -764,6 +764,7 @@ struct sk_config_t
       int     pin_render_thread   = SK_NoPreference;
       int     tearing_mode        = SK_TearingMode::AppControlled;
       int     latency_mode        = SK_LatencyMode::Smooth;
+      int     render_queue        =     1; // Max Render Latency for SK_TearingMode::AlwaysOff_LowLatency/AdaptiveOff
       bool    turn_vsync_off      = false; // Turns VSync Off in Adaptive VSync mode
       bool    flip_discard        =  true; // Enabled by default (7/6/21)
       bool    flip_sequential     = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -930,6 +930,7 @@ struct {
     sk::ParameterInt*     sync_interval_clamp     = nullptr;
     sk::ParameterInt*     tearing_mode            = nullptr;
     sk::ParameterInt*     latency_mode            = nullptr;
+    sk::ParameterInt*     render_queue            = nullptr;
     sk::ParameterInt*     buffer_count            = nullptr;
     sk::ParameterInt*     max_delta_time          = nullptr;
     sk::ParameterBool*    flip_discard            = nullptr;
@@ -2074,6 +2075,7 @@ auto DeclKeybind =
     ConfigEntry (render.framerate.sync_interval_clamp,   L"Maximum Sync Interval (Clamp VSYNC)",                       dll_ini,         L"Render.FrameRate",      L"SyncIntervalClamp"),
     ConfigEntry (render.framerate.tearing_mode,          L"Tearing Mode (Always On/Off or Adaptive)",                  dll_ini,         L"Render.FrameRate",      L"TearingMode"),
     ConfigEntry (render.framerate.latency_mode,          L"Latency reduction behavior (Smooth or Aggressive)",         dll_ini,         L"Render.FrameRate",      L"LatencyMode"),
+    ConfigEntry (render.framerate.render_queue,          L"Max Render Latency for LowLatency/Adaptive Tearing Mode",   dll_ini,         L"Render.FrameRate",      L"RenderQueue"),
     ConfigEntry (render.framerate.prerender_limit,       L"Maximum Frames to Render-Ahead",                            dll_ini,         L"Render.FrameRate",      L"PreRenderLimit"),
     ConfigEntry (render.framerate.sleepless_render,      L"Sleep Free Render Thread",                                  dll_ini,         L"Render.FrameRate",      L"SleeplessRenderThread"),
     ConfigEntry (render.framerate.sleepless_window,      L"Sleep Free Window Thread",                                  dll_ini,         L"Render.FrameRate",      L"SleeplessWindowThread"),
@@ -4892,6 +4894,7 @@ auto DeclKeybind =
   render.framerate.sync_interval_clamp->load (config.render.framerate.sync_interval_clamp);
   render.framerate.tearing_mode->load        (config.render.framerate.tearing_mode);
   render.framerate.latency_mode->load        (config.render.framerate.latency_mode);
+  render.framerate.render_queue->load        (config.render.framerate.render_queue);
 
   if (render.framerate.refresh_rate)
   {
@@ -7195,6 +7198,7 @@ SK_SaveConfig ( std::wstring name,
     render.framerate.sync_interval_clamp->store   (config.render.framerate.sync_interval_clamp);
     render.framerate.tearing_mode->store          (config.render.framerate.tearing_mode);
     render.framerate.latency_mode->store          (config.render.framerate.latency_mode);
+    render.framerate.render_queue->store          (config.render.framerate.render_queue);
     render.framerate.enforcement_policy->store    (config.render.framerate.enforcement_policy);
     render.framerate.enable_etw_tracing->store    (config.render.framerate.enable_etw_tracing);
 


### PR DESCRIPTION
- Added ability to choose latency reduction behavior for "Always Off (Low Latency)" tearing mode:
  - Smooth mode is slower, but uses a parabola curve to minimize judder.
  - Aggressive mode causes more judder, but reduces latency much faster.

- Added a Render Queue slider for "Always Off (Low Latency)" and "Adaptive V-Sync" / "Adaptive (Prefer Off)" tearing modes:
  - Sets a maximum limit of queued frames before Render Latency is allowed to decrease.
  - Render Queue of 0 enables Low-Latency Limiter Mode.

<img width="389" height="180" alt="image" src="https://github.com/user-attachments/assets/d43afdf3-31eb-4b93-83d3-fe6e7e9100a7" />
