### PR TITLE
Fix Windows root directory checks

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8184,7 +8184,7 @@ SK_AppCache_Manager::loadAppCacheForExe (const wchar_t* wszExe)
         std::filesystem::path (wszExe).lexically_normal ();
 
       while (! std::filesystem::equivalent ( path.parent_path    (),
-                                             path.root_directory () ) )
+                                             path.root_name() / path.root_directory () ) )
       {
         if (found_manifest)
           break;
@@ -8356,7 +8356,7 @@ SK_AppCache_Manager::getAppNameFromPath (const wchar_t* wszPath) const
       wchar_t wszProfileName [MAX_PATH + 2] = { };
 
       while (! std::filesystem::equivalent ( path.parent_path    (),
-                                             path.root_directory () ) )
+                                             path.root_name() / path.root_directory () ) )
       {
         *wszProfileName = L'\0';
 
@@ -8530,7 +8530,7 @@ SK_AppCache_Manager::getConfigPathFromAppPath (const wchar_t* wszPath) const
   try
   {
     while (! std::filesystem::equivalent ( path.parent_path    (),
-                                           path.root_directory () ) )
+                                           path.root_name() / path.root_directory () ) )
     {
       if (std::filesystem::is_directory (path / L".egstore"))
       {
@@ -8591,7 +8591,7 @@ SK_AppCache_Manager::getConfigPathFromAppPath (const wchar_t* wszPath) const
       wchar_t wszProfileName [MAX_PATH + 2] = { };
 
       while (! std::filesystem::equivalent ( path.parent_path    (),
-                                             path.root_directory () ) )
+                                             path.root_name() / path.root_directory () ) )
       {
         *wszProfileName = L'\0';
 

--- a/src/storefront/epic.cpp
+++ b/src/storefront/epic.cpp
@@ -1557,7 +1557,7 @@ SK::EOS::AppName (void)
     try
     {
       while (! std::filesystem::equivalent ( path.parent_path    (),
-                                             path.root_directory () ) )
+                                             path.root_name() / path.root_directory () ) )
       {
         if (! name.empty ())
           break;


### PR DESCRIPTION
```cpp
    while (! std::filesystem::equivalent ( path.parent_path    (),
                                           path.root_directory () ) )
```

When the program's current directory is on a different drive than `path`, `root_directory` would point to that drive instead of the same drive as `path`. This would cause SK to stuck in an infinite loop.

Prepending `root_name` would guarantee the comparison will be comparing expected things.