### PR TITLE
Fixes for 2026's Yakuza lineup

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1797,11 +1797,16 @@ enum class SK_GAME_ID
   Ys_Eight,                     // ys8.exe
   PillarsOfEternity2,           // PillarsOfEternityII.exe
   Yakuza0,                      // Yakuza0.exe
+  Yakuza0DirectorsCut,          // Yakuza0_DC.exe
   YakuzaKiwami,                 // YakuzaKiwami.exe
+  YakuzaKiwamiR,                // yakuzakiwami_r.exe
   YakuzaKiwami2,                // YakuzaKiwami2.exe
+  YakuzaKiwami2R,               // yakuzakiwami2_r.exe
+  YakuzaKiwami3,                // YakuzaKiwami3.exe
   YakuzaUnderflow,              // Yakuza*.exe
   YakuzaLikeADragonGaiden,      // LikeADragonGaiden.exe
   YakuzaInfiniteWealth,         // likeadragon8.exe
+  YakuzaLikeADragonPirates,     // LikeADragonPirates.exe
   MonsterHunterWorld,           // MonsterHunterWorld.exe
   MonsterHunterStories2,        // game.exe (fantastic!)
   MonsterHunterRise,            // MonsterHunterRise.exe

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -174,10 +174,15 @@ SK_GetCurrentGameID (void)
           { L"ys8.exe",                                SK_GAME_ID::Ys_Eight                     },
           { L"PillarsOfEternityII.exe",                SK_GAME_ID::PillarsOfEternity2           },
           { L"Yakuza0.exe",                            SK_GAME_ID::Yakuza0                      },
+          { L"yakuza0_dc.exe",                         SK_GAME_ID::Yakuza0DirectorsCut          },
           { L"YakuzaKiwami.exe",                       SK_GAME_ID::YakuzaKiwami                 },
+          { L"yakuzakiwami_r.exe",                     SK_GAME_ID::YakuzaKiwamiR                },
           { L"YakuzaKiwami2.exe",                      SK_GAME_ID::YakuzaKiwami2                },
+          { L"yakuzakiwami2_r.exe",                    SK_GAME_ID::YakuzaKiwami2R               },
+          { L"YakuzaKiwami3.exe",                      SK_GAME_ID::YakuzaKiwami3                },
           { L"LikeADragonGaiden.exe",                  SK_GAME_ID::YakuzaLikeADragonGaiden      },
           { L"likeadragon8.exe",                       SK_GAME_ID::YakuzaInfiniteWealth         },
+          { L"LikeADragonPirates.exe",                 SK_GAME_ID::YakuzaLikeADragonGaiden      },
           { L"MonsterHunterWorld.exe",                 SK_GAME_ID::MonsterHunterWorld           },
           { L"MonsterHunterRise.exe",                  SK_GAME_ID::MonsterHunterRise            },
           { L"Shenmue.exe",                            SK_GAME_ID::Shenmue                      },
@@ -3416,13 +3421,16 @@ auto DeclKeybind =
       }
       break;
 
-      case SK_GAME_ID::YakuzaInfiniteWealth:
-      case SK_GAME_ID::YakuzaLikeADragonGaiden:
+      case SK_GAME_ID::YakuzaInfiniteWealth:      [[fallthrough]];
+      case SK_GAME_ID::YakuzaLikeADragonGaiden:   [[fallthrough]];
+      case SK_GAME_ID::Yakuza0DirectorsCut:       [[fallthrough]];
+      case SK_GAME_ID::YakuzaKiwamiR:             [[fallthrough]];
+      case SK_GAME_ID::YakuzaKiwami2R:            [[fallthrough]];
+      case SK_GAME_ID::YakuzaKiwami3:             [[fallthrough]];
+      case SK_GAME_ID::YakuzaLikeADragonPirates:
       {
         config.render.dxgi.fake_fullscreen_mode   = true;
         config.window.background_render           = true;
-        config.render.dxgi.hooks.
-                            create_swapchain4hwnd = false;
       }
       break;
 


### PR DESCRIPTION
Primarily, a fix for the DPI awareness breakage from #325.

<img width="598" height="789" alt="image" src="https://github.com/user-attachments/assets/1a254204-868f-4144-9c3d-da6ef731b8c1" />

Also adds the "new" ports as their own game IDs so they don't get the default Yakuza behavior, and removes the Streamline fix from earlier since none of the DLSS-supporting games (Kiwami 2 R, Gaiden, Infinite Wealth, Pirate Yakuza and Kiwami 3) seem to need this anymore and this made Kiwami 3 crash.

One could clean this up (and futureproof) some other way by hardcoding all the "old" ports for the underflow fix and removing all the specific Yakuza IDs for the new games, but that'd require more effort potentially breaking the old ports.

For testing, I ran Steam versions of _all the releases_ (both original and DC/R), Kiwami 3, 8, Gaiden, Pirates and also the Xbox version of 0 for good measure and they all seem to inject.