### PR TITLE
Fix vulkan crash on NVIDIA drivers >= 595 in Arknights: Endfield by removing API hook overrides

### DIFF
--- a/SpecialK.vcxproj.filters
+++ b/SpecialK.vcxproj.filters
@@ -3993,7 +3993,7 @@
       <Filter>Source Files\Storefronts\Xbox Live</Filter>
     </ClCompile>
     <ClCompile Include="src\plugins\arknights_endfield.cpp">
-      <Filter>Source Files</Filter>
+      <Filter>Source Files\Plugins</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -4563,9 +4563,6 @@ auto DeclKeybind =
 
         config.textures.d3d11.cache = false;          // cause UI or 2D texture issues
         config.textures.cache.ignore_nonmipped = true;
-        config.apis.dxgi.d3d12.hook = false;
-        config.apis.d3d9.hook = false;
-        config.apis.d3d9ex.hook = false;
 
         config.apis.Vulkan.translate = 1;
         config.apis.NvAPI.vulkan_bridge = 1;


### PR DESCRIPTION
Sorry about this. In my previous PR, I think i added some API overrides in `config.cpp` for endfield and set them to `false`. Because of that, the `[API.HOOK]` `d3d12` option becomes `false` by default on the first launch. This PR removes the API overrides I previously added for Endfield and lets Special K use its original default behavior instead.

It turns out this can cause a crash on NVIDIA drivers >= 595 (thanks to IIIelKot and Meatball_Beam for pointing this out on discord).

From what I understand, when we set `prefer layered on DXGI Swapchain` in nvcp or vulkan bridge on driver version >= 595, special K may detect a native D3D12 swapchain during first creation. If the D3D12 hook is disabled, the code dereferences a null pointer in `dxgi.cpp` around line 7652:
`(*ppSwapChain)->SetPrivateData(SKID_D3D12_SwapChainCommandQueue, sizeof(void *), pCmdQueue)`

Setting the D3D12 hook back to `true` in specialk.ini avoids the crash on my machine. It is set to false by default on first launch because of this mistake at previous PR. Maybe in the future, it also be safer to add a null-pointer check there.