### PR TITLE
Warn when MPOs are disabled through the registry

### DIFF
--- a/include/SpecialK/render/backend.h
+++ b/include/SpecialK/render/backend.h
@@ -766,6 +766,8 @@ public:
   bool isFakeFullscreen (void) const;
   bool isTrueFullscreen (void) const;
 
+  bool isMPODisabled (void);
+
   bool update_outputs = false;
 };
 #pragma pack(pop)

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -2168,7 +2168,18 @@ SK_Display_ResolutionSelectUI (bool bMarkDirty)
 
   if (display.mpo_planes <= 1)
        ImGui::TextColored ( ImVec4 (1.f, 1.f, 0.f, 1.f), "Unsupported " ICON_FA_EXCLAMATION_TRIANGLE );
-  else ImGui::TextColored ( ImVec4 (0.f, 1.f, 0.f, 1.f), "%d", display.mpo_planes );
+  else if (rb.isMPODisabled ())
+  {
+       ImGui::TextColored ( ImVec4 (1.f, 1.f, 0.f, 1.f), "%d (Disabled) " ICON_FA_EXCLAMATION_TRIANGLE, display.mpo_planes );
+
+    if (ImGui::IsItemHovered () && ImGui::BeginTooltip ())
+    {
+      ImGui::Text ("MPOs are available but disabled through the registry; use SKIF to re-enable.");
+      ImGui::EndTooltip ( );
+    }
+  }
+  else
+      ImGui::TextColored ( ImVec4 (0.f, 1.f, 0.f, 1.f), "%d", display.mpo_planes );
 
   auto _PrintEnabled      = [](UINT enabled)
   {

--- a/src/render/dxgi/dxgi_swapchain.cpp
+++ b/src/render/dxgi/dxgi_swapchain.cpp
@@ -2063,6 +2063,72 @@ SK_RenderBackend_V2::isTrueFullscreen (void) const
 }
 
 bool
+SK_RenderBackend_V2::isMPODisabled (void)
+{
+  if (! SK_API_IsDXGIBased (api))
+    return false;
+
+  typedef unsigned long DWMOverlayTestModeFlags;  // -> enum DWMOverlayTestModeFlags_
+
+  enum DWMOverlayTestModeFlags_
+  {
+    DWMOverlayTestModeFlags_None        = 0,      // No overlay test mode flag is set
+    DWMOverlayTestModeFlags_MPORelated1 = 1 << 0, // Unknown purpose (but MPO related)
+    DWMOverlayTestModeFlags_Unknown1    = 1 << 1, // Unknown purpose
+    DWMOverlayTestModeFlags_MPORelated2 = 1 << 2, // Unknown purpose (but MPO related)
+    DWMOverlayTestModeFlags_Unknown2    = 1 << 4, // Unknown purpose
+    DWMOverlayTestModeFlags_INITIAL     = 1 << 16 // Initial dummy value before we check it
+  };
+
+  static DWMOverlayTestModeFlags flagOverlayTestMode = DWMOverlayTestModeFlags_INITIAL;
+  static int iDisableOverlay = 0;
+  static bool  isDisabled    = false;
+
+  if (flagOverlayTestMode != DWMOverlayTestModeFlags_INITIAL)
+    return isDisabled;
+
+  isDisabled = false;
+
+  HKEY hKey;
+  unsigned long size = 1024;
+
+  // Check if GraphicsDrivers's DisableOverlays has MPOs disabled
+  if (ERROR_SUCCESS == RegOpenKeyExW (HKEY_LOCAL_MACHINE, LR"(SYSTEM\CurrentControlSet\Control\GraphicsDrivers\)", 0, KEY_READ | KEY_WOW64_64KEY, &hKey))
+  {
+    if (ERROR_SUCCESS == RegQueryValueEx (hKey, L"DisableOverlays", NULL, NULL, (LPBYTE)&iDisableOverlay, &size))
+    { }
+    else
+      iDisableOverlay = 0;
+
+    RegCloseKey (hKey);
+  }
+
+  else
+    iDisableOverlay = 0;
+
+  // Check if DWM's OverlayTestMode has MPOs disabled
+  if (ERROR_SUCCESS == RegOpenKeyExW (HKEY_LOCAL_MACHINE, LR"(SOFTWARE\Microsoft\Windows\Dwm\)", 0, KEY_READ | KEY_WOW64_64KEY, &hKey))
+  {
+    if (ERROR_SUCCESS == RegQueryValueEx (hKey, L"OverlayTestMode", NULL, NULL, (LPBYTE)&flagOverlayTestMode, &size))
+    { }
+    else
+      flagOverlayTestMode = DWMOverlayTestModeFlags_None;
+
+    RegCloseKey (hKey);
+  }
+
+  else
+    flagOverlayTestMode = DWMOverlayTestModeFlags_None;
+
+  
+  if (iDisableOverlay || ((flagOverlayTestMode & DWMOverlayTestModeFlags_MPORelated1) == DWMOverlayTestModeFlags_MPORelated1 &&
+                          (flagOverlayTestMode & DWMOverlayTestModeFlags_MPORelated2) == DWMOverlayTestModeFlags_MPORelated2))
+    isDisabled = true;
+
+  return isDisabled;
+}
+
+bool
 SK_DXGI_IsFakeFullscreen (IUnknown *pSwapChain) noexcept
 {
   if (SK_ComQIPtr <IDXGISwapChain> pDXGISwapChain (pSwapChain);

--- a/src/render/render_backend.cpp
+++ b/src/render/render_backend.cpp
@@ -4597,6 +4597,17 @@ SK_RenderBackend_V2::updateWDDMCaps (SK_RenderBackend_V2::output_s *pDisplay)
               SK_ImGui_Warning (L"MPOs are not active, consider restarting your driver.")
             );
           }
+
+          // MPOs can be disabled through the registry!
+          else if (isMPODisabled ( ))
+          {
+            if (pDisplay == &displays[active_display] && config.display.warn_no_mpo_planes && pDisplay->mpo_planes > 1)
+            {
+              SK_RunOnce(
+                SK_ImGui_Warning (L"MPOs are available but disabled through the registry; use SKIF to re-enable.")
+              );
+            }
+          }
         }
       }
 


### PR DESCRIPTION
Special K has a slightly inaccurate MPO reporting since it does not take the state of the registry into account.

This adds a new function, SK_RenderBackend_V2::isMPODisabled(), that evaluates once at launch and produces:
- A warning on launch if `config.display.warn_no_mpo_planes` is enabled.
- A warning in the Display menu if MPO planes would otherwise be available if not for being disabled in the registry.

The function is basically the one from SKIF copied straight over.

<img width="2880" height="1620" alt="image" src="https://github.com/user-attachments/assets/c7279b0e-764f-493f-a4be-b40811ef4388" />
