### PR TITLE
NieR Automata: Disable + inform why FPS cap is unavailable

### DIFF
--- a/src/plugins/nier.cpp
+++ b/src/plugins/nier.cpp
@@ -35,6 +35,8 @@
 #include <SpecialK/render/dxgi/dxgi_hdr.h>
 #include <SpecialK/render/d3d11/d3d11_core.h>
 
+#include <imgui/font_awesome.h>
+
 
 
 #define FAR_VERSION_NUM L"0.10.3"
@@ -2355,7 +2357,13 @@ SK_FAR_PlugInCfg (void)
 #ifdef WORKING_FPS_UNCAP
 
       if (game_state.needFPSCap2())
-        ImGui::BeginDisabled();
+      {
+        ImGui::BeginGroup    ();
+        ImGui::TextColored   ( ImVec4 (1.f, 1.f, 0.f, 1.f),
+                               "  " ICON_FA_EXCLAMATION_TRIANGLE );
+        ImGui::SameLine      ();
+        ImGui::BeginDisabled ();
+      }
 
       if (ImGui::Checkbox ("Remove 60 FPS Cap  ", &remove_cap))
       {
@@ -2373,7 +2381,8 @@ SK_FAR_PlugInCfg (void)
 
       if (game_state.needFPSCap2())
       {
-        ImGui::EndDisabled();
+        ImGui::EndDisabled   ();
+        ImGui::EndGroup      ();
       }
 
       if (ImGui::IsItemHovered (ImGuiHoveredFlags_AllowWhenDisabled))

--- a/src/plugins/nier.cpp
+++ b/src/plugins/nier.cpp
@@ -101,6 +101,7 @@ struct far_game_state_s
                            return ( pHacking   != nullptr && (*pHacking   & 0x2) != 0 );
     }
   bool isShorting (void) { return ( pShortcuts != nullptr && (*pShortcuts & 0x1) != 0 ); }
+  bool needFPSCap2(void) { return ( isInMenu() || isLoading() || isHacking() || isShorting() ); }
 
   bool needFPSCap (void) {
     if (! patchable)
@@ -2352,6 +2353,10 @@ SK_FAR_PlugInCfg (void)
       bool remove_cap = far_uncap_fps->get_value ();
 
 #ifdef WORKING_FPS_UNCAP
+
+      if (game_state.needFPSCap2())
+        ImGui::BeginDisabled();
+
       if (ImGui::Checkbox ("Remove 60 FPS Cap  ", &remove_cap))
       {
         changed = true;
@@ -2366,11 +2371,27 @@ SK_FAR_PlugInCfg (void)
         }
       }
 
-      if (ImGui::IsItemHovered ())
+      if (game_state.needFPSCap2())
+      {
+        ImGui::EndDisabled();
+      }
+
+      if (ImGui::IsItemHovered (ImGuiHoveredFlags_AllowWhenDisabled))
       {
         ImGui::BeginTooltip  ();
-        ImGui::Text          ("Can be toggled with "); ImGui::SameLine ();
-        ImGui::TextColored   (ImVec4 (1.0f, 0.8f, 0.1f, 1.0f), "Ctrl + Shift + .");
+
+        if (game_state.needFPSCap2())
+        {
+          ImGui::Text        ("An FPS cap is currently being enforced for compatibility reasons.");
+          ImGui::Text        ("The setting will be made available in-game during regular gameplay.");
+        }
+
+        else
+        {
+          ImGui::Text          ("Can be toggled with "); ImGui::SameLine ();
+          ImGui::TextColored   (ImVec4 (1.0f, 0.8f, 0.1f, 1.0f), "Ctrl + Shift + .");
+        }
+        
         ImGui::Separator     ();
         ImGui::TreePush      ("");
 


### PR DESCRIPTION
This should hopefully reduce the number of support requests.

Note, this change highlighted that isInMenu() is not returning true in the main menu on the initial launch of the game. Only if the player exits back to the main menu after having launched a save does the call return true while on the main menu.

<img width="825" height="160" alt="image" src="https://github.com/user-attachments/assets/90646b4d-63c0-4bac-a831-dc7ab311097b" />