### PR TITLE
Delay Xbox Game Bar callback registration during startup

### DIFF
--- a/src/storefront/xbox.cpp
+++ b/src/storefront/xbox.cpp
@@ -65,10 +65,11 @@ SK::Xbox::Init (void)
   }
 }
 
-static boolean                visible          = false;
+static boolean                visible              = false;
 static EventRegistrationToken visibility_event;
-static boolean                input_redirected = false;
+static boolean                input_redirected     = false;
 static EventRegistrationToken input_event;
+static boolean                callbacks_registered = false;
 
 void
 SK::Xbox::Shutdown (void)
@@ -136,12 +137,27 @@ SK_Xbox_GetOverlayState_UsingCallbacks (void)
       }
     );
 
-  SK_RunOnce (
-    SK_GameBar_Statics->get_Visible                  (                                     &visible);
-    SK_GameBar_Statics->add_VisibilityChanged        (visibility_callback.Get (), &visibility_event);
-    SK_GameBar_Statics->get_IsInputRedirected        (                            &input_redirected);
-    SK_GameBar_Statics->add_IsInputRedirectedChanged (     input_callback.Get (),      &input_event);
-  );
+  if (!callbacks_registered)
+  {
+    //
+    // Delay callback registration briefly after startup to avoid
+    // potential initialization ordering issues during early game
+    // startup. Some systems appear to freeze during event
+    // registration if this occurs too early.
+    //
+    if (SK_GetFramesDrawn() <= 180)
+      return false;
+
+    SK_RunOnce(
+      SK_GameBar_Statics->get_Visible                  (                                     &visible);
+      SK_GameBar_Statics->add_VisibilityChanged        (visibility_callback.Get (), &visibility_event);
+      SK_GameBar_Statics->get_IsInputRedirected        (                            &input_redirected);
+      SK_GameBar_Statics->add_IsInputRedirectedChanged (     input_callback.Get (),      &input_event);
+
+      callbacks_registered = true;
+      SK_LOGi0(L"SK_Xbox_GetOverlayState_UsingCallbacks: GameBar Callbacks registered")
+    );
+  }
 
   return
     (visible && input_redirected);
@@ -155,7 +171,7 @@ SK_Xbox_GetOverlayState (bool real)
 
   std::ignore = real;
 
-  SK_RunOnce (SK_Xbox_GetOverlayState_UsingCallbacks ());
+  SK_Xbox_GetOverlayState_UsingCallbacks ();
 
   static boolean has_callbacks =
     (visibility_event.value != 0);

--- a/src/storefront/xbox.cpp
+++ b/src/storefront/xbox.cpp
@@ -114,11 +114,11 @@ SK_Xbox_GetOverlayState_WithCaching (void)
   return redirected != false;
 }
 
-boolean
-SK_Xbox_GetOverlayState_UsingCallbacks (void)
+void
+SK_Xbox_RegisterCallbacks (void)
 {
-  if (! SK_GameBar_Statics)
-    return false;
+  if (! SK_GameBar_Statics || callbacks_registered)
+    return;
 
   static auto visibility_callback =
     Microsoft::WRL::Callback <ABI::Windows::Foundation::IEventHandler <IInspectable *>> (
@@ -137,27 +137,23 @@ SK_Xbox_GetOverlayState_UsingCallbacks (void)
       }
     );
 
-  if (!callbacks_registered)
-  {
-    //
-    // Delay callback registration briefly after startup to avoid
-    // potential initialization ordering issues during early game
-    // startup. Some systems appear to freeze during event
-    // registration if this occurs too early.
-    //
-    if (SK_GetFramesDrawn() <= 180)
-      return false;
+  SK_RunOnce (
+    SK_GameBar_Statics->get_Visible                  (                                     &visible);
+    SK_GameBar_Statics->add_VisibilityChanged        (visibility_callback.Get (), &visibility_event);
+    SK_GameBar_Statics->get_IsInputRedirected        (                            &input_redirected);
+    SK_GameBar_Statics->add_IsInputRedirectedChanged (     input_callback.Get (),      &input_event);
 
-    SK_RunOnce(
-      SK_GameBar_Statics->get_Visible                  (                                     &visible);
-      SK_GameBar_Statics->add_VisibilityChanged        (visibility_callback.Get (), &visibility_event);
-      SK_GameBar_Statics->get_IsInputRedirected        (                            &input_redirected);
-      SK_GameBar_Statics->add_IsInputRedirectedChanged (     input_callback.Get (),      &input_event);
+    callbacks_registered = true;
 
-      callbacks_registered = true;
-      SK_LOGi0(L"SK_Xbox_GetOverlayState_UsingCallbacks: GameBar Callbacks registered")
-    );
-  }
+    SK_LOGi0 (L"SK_Xbox_RegisterCallbacks: GameBar callbacks registered");
+  );
+}
+
+boolean
+SK_Xbox_GetOverlayState_UsingCallbacks (void)
+{
+  if (! SK_GameBar_Statics)
+    return false;
 
   return
     (visible && input_redirected);
@@ -171,9 +167,19 @@ SK_Xbox_GetOverlayState (bool real)
 
   std::ignore = real;
 
-  SK_Xbox_GetOverlayState_UsingCallbacks ();
+  //
+  // Delay callback registration briefly after startup to avoid
+  // potential initialization ordering issues during early game
+  // startup. Some systems appear to freeze during event
+  // registration if this occurs too early.
+  //
+  if (! callbacks_registered &&
+      SK_GetFramesDrawn () > 100)
+  {
+    SK_Xbox_RegisterCallbacks ();
+  }
 
-  static boolean has_callbacks =
+  boolean has_callbacks =
     (visibility_event.value != 0);
 
   //

--- a/src/storefront/xbox.cpp
+++ b/src/storefront/xbox.cpp
@@ -120,6 +120,12 @@ SK_Xbox_RegisterCallbacks (void)
   if (! SK_GameBar_Statics || callbacks_registered)
     return;
 
+  SK_LOGi0 (
+    L"SK_Xbox_RegisterCallbacks: attempting registration "
+    L"(frame=%llu)",
+    SK_GetFramesDrawn()
+  );
+
   static auto visibility_callback =
     Microsoft::WRL::Callback <ABI::Windows::Foundation::IEventHandler <IInspectable *>> (
       [](IInspectable*, IInspectable*)
@@ -168,13 +174,15 @@ SK_Xbox_GetOverlayState (bool real)
   std::ignore = real;
 
   //
-  // Delay callback registration briefly after startup to avoid
-  // potential initialization ordering issues during early game
-  // startup. Some systems appear to freeze during event
-  // registration if this occurs too early.
+  // Wait until the first frame has been rendered before registering
+  // Xbox/Game Bar callbacks. Some games create temporary startup or
+  // splash windows before the real render loop begins, and this
+  // function may be called during frame 0 before rendering is active.
+  // Registering callbacks that early has been observed to cause
+  // initialization ordering issues or freezes on some systems.
   //
   if (! callbacks_registered &&
-      SK_GetFramesDrawn () > 100)
+      SK_GetFramesDrawn () > 0)
   {
     SK_Xbox_RegisterCallbacks ();
   }


### PR DESCRIPTION
This change delays callback registration briefly after startup and falls back to the existing polling path until registration occurs and fixes a potential startup timing/race-condition issue where Xbox Game Bar callback registration can completely stall game startup on some systems.

---

Here's a video demonstrating the issue and showing that reverting to an earlier release (before the callback-based implementation was introduced) resolves it:

https://github.com/user-attachments/assets/df590b02-f310-413c-b8ce-855de564d362

The startup stalls appear to occur during these callback registration calls:

<img width="706" height="161" alt="image" src="https://github.com/user-attachments/assets/492dbdb2-4c9f-4b33-bea0-de97cb46fd35" />

Through testing I was able to find out that execution entered these functions but never returned during startup:

```cpp
SK_GameBar_Statics->add_VisibilityChanged (...);
SK_GameBar_Statics->add_IsInputRedirectedChanged (...);
```

The issue appears to have been introduced by commit where the callbacks were added, which introduced callback-based Xbox Game Bar handling:

https://github.com/SpecialKO/SpecialK/blob/fd08d1706a7984db48f7c2db5d9e68f26bfe5971/src/storefront/xbox.cpp#L141-L143