### PR TITLE
[codex] Add CPU topology spoofing

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -1550,7 +1550,10 @@ struct sk_config_t
     bool    highest_priority    = false;
     bool    deny_foreign_change =  true;
     bool    perf_cores_only     = false;
+    bool    cpu_spoof_enable    = false;
     int     minimum_render_prio = THREAD_PRIORITY_ABOVE_NORMAL;
+    int     cpu_spoof_logical   = 0;
+    int     cpu_spoof_physical  = 0;
     DWORD   available_cpu_cores =   1UL;
     int64_t cpu_affinity_mask   = 0xFFFFFFFFFFFFFFFFULL;
   } priority;

--- a/include/SpecialK/diagnostics/cpu.h
+++ b/include/SpecialK/diagnostics/cpu.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <string>
 
 const std::vector <uintptr_t>&
 SK_CPU_GetLogicalCorePairs (void);
@@ -75,7 +76,18 @@ bool                 SK_Power_InitEffectiveModeCallbacks (void);
 bool                 SK_Power_StopEffectiveModeCallbacks (void);
 
 void                 SK_CPU_InstallHooks                 (void);
+void                 SK_CPU_EarlyTopologySpoof_Install   (void);
 bool                 SK_CPU_IsZen                        (void);
 bool                 SK_CPU_TestForMWAITX                (void);
+
+std::wstring         SK_CPU_AppCompatSDB_GetPath         (void);
+bool                 SK_CPU_AppCompatSDB_WriteProcessorCountLie
+                                                            (const wchar_t* exe_name,
+                                                             const wchar_t* app_name,
+                                                             int            processor_count,
+                                                             std::wstring*  out_path = nullptr);
+bool                 SK_CPU_AppCompatSDB_RunInstaller    (const wchar_t* sdb_path,
+                                                             bool           uninstall,
+                                                             bool           update = false);
 
 #endif /* __SK__CPU_H__ */

--- a/src/SpecialK.cpp
+++ b/src/SpecialK.cpp
@@ -26,6 +26,7 @@
 
 #include <Aux_ulib.h>
 
+#include <SpecialK/diagnostics/cpu.h>
 #include <SpecialK/render/d3d9/d3d9_backend.h>
 #include <SpecialK/render/gl/opengl_backend.h>
 
@@ -592,6 +593,7 @@ DllMain ( HMODULE hModule,
       SK_TLS_Acquire         ();
       SK_EstablishRootPath   ();
       SK_CreateTeardownEvent ();
+      SK_CPU_EarlyTopologySpoof_Install ();
 
       SK_TLS_Bottom ()->debug.in_DllMain = true;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -971,7 +971,6 @@ struct {
     sk::ParameterBool*    sleepless_window        = nullptr;
     sk::ParameterBool*    sleepless_render        = nullptr;
     sk::ParameterBool*    enable_mmcss            = nullptr;
-    sk::ParameterInt*     override_cpu_count      = nullptr;
     sk::ParameterInt*     enforcement_policy      = nullptr;
     sk::ParameterBool*    drop_late_frames        = nullptr;
     sk::ParameterBool*    auto_low_latency        = nullptr;
@@ -1313,6 +1312,9 @@ struct {
     sk::ParameterInt*     min_render_priority     = nullptr;
     sk::ParameterInt64*   cpu_affinity_mask       = nullptr;
     sk::ParameterBool*    perf_cores_only         = nullptr;
+    sk::ParameterBool*    cpu_spoof_enable        = nullptr;
+    sk::ParameterInt*     cpu_spoof_logical       = nullptr;
+    sk::ParameterInt*     cpu_spoof_physical      = nullptr;
   } priority;
 } scheduling;
 
@@ -2135,7 +2137,6 @@ auto DeclKeybind =
     ConfigEntry (render.framerate.control.render_ahead,  L"Maximum number of CPU-side frames to work ahead of GPU.",   dll_ini,         L"FrameRate.Engine",      L"MaxRenderAheadFrames"),
     ConfigEntry (render.framerate.engine.
                                       allow_latency_wait,L"Allow the game to use a Latency Waitable SwapChain.",       dll_ini,         L"FrameRate.Engine",      L"AllowDXGILatencyWait"),
-    ConfigEntry (render.framerate.override_cpu_count,    L"Number of CPU cores to tell the game about",                dll_ini,         L"FrameRate.Engine",      L"OverrideCPUCoreCount"),
     ConfigEntry (render.framerate.max_timer_resolution,  L"Set the process timer resolution to the maximum supported", dll_ini,         L"FrameRate.Engine",      L"UseMaxTimerResolution"),
     ConfigEntry (render.framerate.force_high_res_timers, L"Force Waitable Timer code to use Win10 High-Res Timers",    dll_ini,         L"FrameRate.Engine",      L"ForceHighResTimers"),
     ConfigEntry (render.framerate.pace_game_thread,      L"Pace the game thread in supported engines (i.e. Unity)",    dll_ini,         L"FrameRate.Engine",      L"PaceGameThread"),
@@ -2354,6 +2355,9 @@ auto DeclKeybind =
     ConfigEntry (scheduling.priority.min_render_priority,L"Minimum priority for a game's render thread",               dll_ini,         L"Scheduler.Boost",       L"MinimumRenderThreadPriority"),
     ConfigEntry (scheduling.priority.cpu_affinity_mask,  L"Mask of CPU cores the process is eligible for scheduling.", dll_ini,         L"Scheduler.System",      L"ProcessorAffinityMask"),
     ConfigEntry (scheduling.priority.perf_cores_only,    L"Limit the scheduler to Intel P-Cores",                      dll_ini,         L"Scheduler.System",      L"PerformanceCoresOnly"),
+    ConfigEntry (scheduling.priority.cpu_spoof_enable,   L"Spoof Win32 CPU topology APIs for the current process",     dll_ini,         L"Scheduler.CPUSpoof",    L"Enable"),
+    ConfigEntry (scheduling.priority.cpu_spoof_logical,  L"Logical processor count exposed to the game",               dll_ini,         L"Scheduler.CPUSpoof",    L"LogicalProcessors"),
+    ConfigEntry (scheduling.priority.cpu_spoof_physical, L"Physical core count exposed to the game",                   dll_ini,         L"Scheduler.CPUSpoof",    L"PhysicalCores"),
 
     ConfigEntry (sound.minimize_latency,                 L"Minimize Audio Latency while Game is Running",              dll_ini,         L"Sound.Mixing",          L"MinimizeLatency"),
 
@@ -4968,7 +4972,6 @@ auto DeclKeybind =
 //                  render_ahead->load        (config.render.framerate.max_render_ahead);
   render.framerate.engine.allow_latency_wait
                                      ->load   (config.render.framerate.engine_overrides.allow_latency_wait);
-  render.framerate.override_cpu_count->load   (config.render.framerate.override_num_cpus);
   render.framerate.max_timer_resolution->load (config.render.framerate.max_timer_resolution);
   render.framerate.force_high_res_timers->load(config.render.framerate.force_high_res_timers);
   render.framerate.pace_game_thread->load     (config.render.framerate.pace_game_thread);
@@ -5107,6 +5110,9 @@ auto DeclKeybind =
   }
 
   scheduling.priority.perf_cores_only->load     (config.priority.perf_cores_only);
+  scheduling.priority.cpu_spoof_enable->load    (config.priority.cpu_spoof_enable);
+  scheduling.priority.cpu_spoof_logical->load   (config.priority.cpu_spoof_logical);
+  scheduling.priority.cpu_spoof_physical->load  (config.priority.cpu_spoof_physical);
 
   if (config.priority.raise_always)
     SetPriorityClass (GetCurrentProcess (), ABOVE_NORMAL_PRIORITY_CLASS);
@@ -7360,7 +7366,6 @@ SK_SaveConfig ( std::wstring name,
   render.framerate.boost_compositor_clock->
                                        store (config.render.framerate.boost_composite_clock);
 
-  render.framerate.override_cpu_count->store (config.render.framerate.override_num_cpus);
   render.framerate.max_timer_resolution->
                                        store (config.render.framerate.max_timer_resolution);
   render.framerate.force_high_res_timers->
@@ -7388,6 +7393,9 @@ SK_SaveConfig ( std::wstring name,
     scheduling.priority.min_render_priority->store (config.priority.minimum_render_prio);
     scheduling.priority.cpu_affinity_mask->store   (config.priority.cpu_affinity_mask);
     scheduling.priority.perf_cores_only->store     (config.priority.perf_cores_only);
+    scheduling.priority.cpu_spoof_enable->store    (config.priority.cpu_spoof_enable);
+    scheduling.priority.cpu_spoof_logical->store   (config.priority.cpu_spoof_logical);
+    scheduling.priority.cpu_spoof_physical->store  (config.priority.cpu_spoof_physical);
 
     if (render.framerate.rescan_ratio != nullptr)
     {

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -44,6 +44,8 @@
 #include <SpecialK/control_panel/platform.h>
 #include <SpecialK/control_panel/window.h>
 
+#include <SpecialK/diagnostics/cpu.h>
+
 #include <SpecialK/storefront/epic.h>
 #include <SpecialK/storefront/gog.h>
 
@@ -7484,19 +7486,39 @@ static constexpr uint32_t UPLAY_OVERLAY_PS_CRC32C  { 0x35ae281c };
           }
 #endif
 
-          bool spoof =
-            ( config.render.framerate.override_num_cpus != SK_NoPreference );
-
           static SYSTEM_INFO             si = { };
           SK_RunOnce (SK_GetSystemInfo (&si));
 
-          if ( ImGui::Checkbox ("Reduce CPUs", &spoof) )
+          const int max_spoofed_processors =
+            static_cast <int> (std::max (1UL, si.dwNumberOfProcessors));
+
+          bool cpu_spoof =
+            config.priority.cpu_spoof_enable;
+
+          static bool cpu_spoof_orig =
+            config.priority.cpu_spoof_enable;
+          static int  cpu_logical_orig =
+            config.priority.cpu_spoof_logical;
+          static int  cpu_physical_orig =
+            config.priority.cpu_spoof_physical;
+
+          if ( ImGui::Checkbox ("Spoof CPU Topology", &cpu_spoof) )
           {
-            config.render.framerate.override_num_cpus =
-              ( spoof ? si.dwNumberOfProcessors : -1 );
+            config.priority.cpu_spoof_enable = cpu_spoof;
+
+            if (cpu_spoof)
+            {
+              if (config.priority.cpu_spoof_logical <= 0)
+                config.priority.cpu_spoof_logical =
+                  max_spoofed_processors;
+
+              if (config.priority.cpu_spoof_physical <= 0)
+                config.priority.cpu_spoof_physical =
+                  std::max (1, config.priority.cpu_spoof_logical / 2);
+            }
           }
 
-          ImGui::SetItemTooltip ("Useful in Unity games -- set lower than actual to fix negative performance scaling.");
+          ImGui::SetItemTooltip ("Overrides Win32 CPU topology APIs for games that size worker pools from CPU count.");
 
           ImGui::SameLine ();
           ImGui::Checkbox ("Upgrade Low-Res Timers", &config.render.framerate.force_high_res_timers);
@@ -7514,14 +7536,117 @@ static constexpr uint32_t UPLAY_OVERLAY_PS_CRC32C  { 0x35ae281c };
 
           ImGui::EndGroup ();
 
-          if (spoof)
+          static std::string appcompat_sdb_status;
+
+          if (config.priority.cpu_spoof_enable)
           {
+            config.priority.cpu_spoof_logical =
+              std::clamp ( config.priority.cpu_spoof_logical,
+                1, max_spoofed_processors );
+
+            config.priority.cpu_spoof_physical =
+              std::clamp ( config.priority.cpu_spoof_physical,
+                1, config.priority.cpu_spoof_logical );
+
             ImGui::BeginGroup ();
-            ImGui::SliderInt  ( "###SPOOF_CPU_COUNT",
-                                &config.render.framerate.override_num_cpus,
-                                  1, si.dwNumberOfProcessors,
-                                    "Number of CPUs: %d" );
+            ImGui::SliderInt  ( "###SPOOF_CPU_LOGICAL",
+                                &config.priority.cpu_spoof_logical,
+                                  1, max_spoofed_processors,
+                                    "Logical Processors: %d" );
+            ImGui::SliderInt  ( "###SPOOF_CPU_PHYSICAL",
+                                &config.priority.cpu_spoof_physical,
+                                  1, config.priority.cpu_spoof_logical,
+                                    "Physical Cores: %d" );
             ImGui::EndGroup   ();
+
+            if ( cpu_spoof_orig != config.priority.cpu_spoof_enable ||
+                 cpu_logical_orig != config.priority.cpu_spoof_logical ||
+                 cpu_physical_orig != config.priority.cpu_spoof_physical )
+            {
+              ImGui::PushStyleColor (ImGuiCol_Text, (ImVec4&&)ImColor::HSV (.3f, .8f, .9f));
+              ImGui::BulletText     ("Game Restart Required");
+              ImGui::PopStyleColor  ();
+            }
+          }
+
+          const int appcompat_sdb_logical =
+            std::clamp ( config.priority.cpu_spoof_logical > 0 ?
+                           config.priority.cpu_spoof_logical :
+                           max_spoofed_processors,
+                         1, max_spoofed_processors );
+
+          ImGui::Separator ();
+
+          if (ImGui::Button ("Install / Update AMD AppCompat SDB"))
+          {
+            std::wstring sdb_path;
+
+            const bool wrote_sdb =
+              SK_CPU_AppCompatSDB_WriteProcessorCountLie (
+                SK_GetHostApp (),
+                nullptr,
+                appcompat_sdb_logical,
+                &sdb_path
+              );
+
+            const bool launched_installer =
+              wrote_sdb &&
+                SK_CPU_AppCompatSDB_RunInstaller (
+                  sdb_path.c_str (), false, true
+                );
+
+            appcompat_sdb_status =
+              launched_installer ?
+                "SDB install/update command launched" :
+                "SDB install/update failed";
+          }
+
+          if (ImGui::BeginItemTooltip ())
+          {
+            ImGui::Text       ("Installs Windows AppCompat ProcessorCountLie for this game.");
+            ImGui::Separator  ();
+            ImGui::BulletText ("Logical Processors: %d", appcompat_sdb_logical);
+            ImGui::BulletText ("Requires UAC approval and a full game restart.");
+            ImGui::EndTooltip ();
+          }
+
+          ImGui::SameLine ();
+
+          if (ImGui::Button ("Uninstall AMD AppCompat SDB"))
+          {
+            std::wstring sdb_path;
+
+            const bool wrote_sdb =
+              SK_CPU_AppCompatSDB_WriteProcessorCountLie (
+                SK_GetHostApp (),
+                nullptr,
+                appcompat_sdb_logical,
+                &sdb_path
+              );
+
+            const bool launched_installer =
+              wrote_sdb &&
+                SK_CPU_AppCompatSDB_RunInstaller (
+                  sdb_path.c_str (), true, false
+                );
+
+            appcompat_sdb_status =
+              launched_installer ?
+                "SDB uninstall command launched" :
+                "SDB uninstall failed";
+          }
+
+          if (ImGui::BeginItemTooltip ())
+          {
+            ImGui::Text       ("Removes this game's Special K ProcessorCountLie database.");
+            ImGui::Separator  ();
+            ImGui::BulletText ("Requires UAC approval and a full game restart.");
+            ImGui::EndTooltip ();
+          }
+
+          if (! appcompat_sdb_status.empty ())
+          {
+            ImGui::BulletText ("%s", appcompat_sdb_status.c_str ());
           }
 
           // Only show these for debug purposes, normal users never need to see

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1125,6 +1125,17 @@ void BasicInit (void)
   // Setup unhooked function pointers
   SK_PreInitLoadLibrary ();
 
+  SK_CPU_InstallHooks ();
+  {
+    const bool apply_queued_was_enabled =
+      SK_EnableApplyQueuedHooks ();
+
+    SK_ApplyQueuedHooks ();
+
+    if (! apply_queued_was_enabled)
+      SK_DisableApplyQueuedHooks ();
+  }
+
   if (config.system.handle_crashes)
     SK::Diagnostics::CrashHandler::Init   ();
   SK::Diagnostics::CrashHandler::InitSyms ();
@@ -2204,6 +2215,17 @@ SK_StartupCore (const wchar_t* backend, void* callback)
                    (&SK_RenderBackend::frames_drawn, 0);
 
     dll_log->LogEx (false, L"done!\n");
+  }
+
+  SK_CPU_InstallHooks ();
+  {
+    const bool apply_queued_was_enabled =
+      SK_EnableApplyQueuedHooks ();
+
+    SK_ApplyQueuedHooks ();
+
+    if (! apply_queued_was_enabled)
+      SK_DisableApplyQueuedHooks ();
   }
 
   // As of ReShade 6.6.0, ReShade will poop the bed if it is dxgi.dll and not loaded before SK is,

--- a/src/diagnostics/cpu.cpp
+++ b/src/diagnostics/cpu.cpp
@@ -25,9 +25,15 @@
 
 #include <SpecialK/diagnostics/cpu.h>
 
+#include <TlHelp32.h>
+
 typedef void (WINAPI *GetSystemInfo_pfn)(LPSYSTEM_INFO);
                       GetSystemInfo_pfn
                       GetSystemInfo_Original = nullptr;
+
+typedef void (WINAPI *GetNativeSystemInfo_pfn)(LPSYSTEM_INFO);
+                      GetNativeSystemInfo_pfn
+                      GetNativeSystemInfo_Original = nullptr;
 
 typedef BOOL (WINAPI *GetLogicalProcessorInformation_pfn)(PSYSTEM_LOGICAL_PROCESSOR_INFORMATION,PDWORD);
                       GetLogicalProcessorInformation_pfn
@@ -37,6 +43,54 @@ typedef BOOL (WINAPI *GetLogicalProcessorInformationEx_pfn)(LOGICAL_PROCESSOR_RE
                        GetLogicalProcessorInformationEx_pfn
                        GetLogicalProcessorInformationEx_Original = nullptr;
 
+typedef DWORD (WINAPI *GetActiveProcessorCount_pfn)(WORD);
+                       GetActiveProcessorCount_pfn
+                       GetActiveProcessorCount_Original = nullptr;
+
+typedef WORD (WINAPI *GetActiveProcessorGroupCount_pfn)(void);
+                      GetActiveProcessorGroupCount_pfn
+                      GetActiveProcessorGroupCount_Original = nullptr;
+
+typedef DWORD (WINAPI *GetMaximumProcessorCount_pfn)(WORD);
+                       GetMaximumProcessorCount_pfn
+                       GetMaximumProcessorCount_Original = nullptr;
+
+typedef WORD (WINAPI *GetMaximumProcessorGroupCount_pfn)(void);
+                      GetMaximumProcessorGroupCount_pfn
+                      GetMaximumProcessorGroupCount_Original = nullptr;
+
+typedef BOOL (WINAPI *GetProcessAffinityMask_pfn)(HANDLE,PDWORD_PTR,PDWORD_PTR);
+                       GetProcessAffinityMask_pfn
+                       GetProcessAffinityMask_Original = nullptr;
+
+typedef VOID (WINAPI *SetThreadpoolThreadMaximum_pfn)(PTP_POOL,DWORD);
+                       SetThreadpoolThreadMaximum_pfn
+                       SetThreadpoolThreadMaximum_Original = nullptr;
+
+typedef BOOL (WINAPI *SetThreadpoolThreadMinimum_pfn)(PTP_POOL,DWORD);
+                       SetThreadpoolThreadMinimum_pfn
+                       SetThreadpoolThreadMinimum_Original = nullptr;
+
+typedef unsigned int (__cdecl *MSVCP_Thrd_hardware_concurrency_pfn)(void);
+                              MSVCP_Thrd_hardware_concurrency_pfn
+                              MSVCP_Thrd_hardware_concurrency_Original = nullptr;
+
+typedef FARPROC (WINAPI *SK_CPU_Early_GetProcAddress_pfn)(HMODULE,LPCSTR);
+typedef HMODULE (WINAPI *SK_CPU_Early_LoadLibraryW_pfn)(LPCWSTR);
+typedef HMODULE (WINAPI *SK_CPU_Early_LoadLibraryA_pfn)(LPCSTR);
+typedef HMODULE (WINAPI *SK_CPU_Early_LoadLibraryExW_pfn)(LPCWSTR,HANDLE,DWORD);
+typedef HMODULE (WINAPI *SK_CPU_Early_LoadLibraryExA_pfn)(LPCSTR,HANDLE,DWORD);
+
+BOOL  WINAPI GetLogicalProcessorInformation_Detour   (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION,PDWORD);
+BOOL  WINAPI GetLogicalProcessorInformationEx_Detour (LOGICAL_PROCESSOR_RELATIONSHIP,PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,PDWORD);
+void  WINAPI GetSystemInfo_Detour                    (LPSYSTEM_INFO);
+void  WINAPI GetNativeSystemInfo_Detour              (LPSYSTEM_INFO);
+DWORD WINAPI GetActiveProcessorCount_Detour          (WORD);
+WORD  WINAPI GetActiveProcessorGroupCount_Detour     (void);
+DWORD WINAPI GetMaximumProcessorCount_Detour         (WORD);
+WORD  WINAPI GetMaximumProcessorGroupCount_Detour    (void);
+BOOL  WINAPI GetProcessAffinityMask_Detour           (HANDLE,PDWORD_PTR,PDWORD_PTR);
+
 size_t
 SK_CPU_CountPhysicalCores (void);
 
@@ -45,13 +99,1803 @@ SK_CPU_CountPhysicalCores (void);
 #endif
 #define __SK_SUBSYSTEM__ L"  CPUMgr  "
 
+#ifndef LTP_PC_SMT
+#define LTP_PC_SMT 0x1
+#endif
+
+#ifndef ALL_PROCESSOR_GROUPS
+#define ALL_PROCESSOR_GROUPS 0xffff
+#endif
+
+namespace
+{
+  SK_CPU_Early_GetProcAddress_pfn
+    SK_CPU_Early_GetProcAddress_Original = nullptr;
+
+  SK_CPU_Early_LoadLibraryW_pfn
+    SK_CPU_Early_LoadLibraryW_Original = nullptr;
+
+  SK_CPU_Early_LoadLibraryA_pfn
+    SK_CPU_Early_LoadLibraryA_Original = nullptr;
+
+  SK_CPU_Early_LoadLibraryExW_pfn
+    SK_CPU_Early_LoadLibraryExW_Original = nullptr;
+
+  SK_CPU_Early_LoadLibraryExA_pfn
+    SK_CPU_Early_LoadLibraryExA_Original = nullptr;
+
+  volatile LONG
+    SK_CPU_EarlyTopologySpoof_Patching = FALSE;
+
+  wchar_t
+    SK_CPU_EarlyTopologySpoof_WindowsDir [MAX_PATH] = { };
+
+  constexpr DWORD
+  SK_CPU_Spoof_MaxLogicalProcessors (void)
+  {
+    return static_cast <DWORD> (sizeof (ULONG_PTR) * 8);
+  }
+
+  bool
+  SK_CPU_Spoof_IsEnabled (void)
+  {
+    return
+      config.priority.cpu_spoof_enable &&
+      ( config.priority.cpu_spoof_logical  > 0 ||
+        config.priority.cpu_spoof_physical > 0 );
+  }
+
+  DWORD
+  SK_CPU_Spoof_LogicalProcessors (void)
+  {
+    int logical =
+      config.priority.cpu_spoof_logical;
+
+    if (logical <= 0)
+      logical =
+        config.priority.cpu_spoof_physical;
+
+    logical =
+      std::clamp ( logical, 1,
+        static_cast <int> (SK_CPU_Spoof_MaxLogicalProcessors ()) );
+
+    return
+      static_cast <DWORD> (logical);
+  }
+
+  DWORD
+  SK_CPU_Spoof_PhysicalCores (void)
+  {
+    int physical =
+      config.priority.cpu_spoof_physical;
+
+    if (physical <= 0)
+      physical =
+        config.priority.cpu_spoof_logical;
+
+    physical =
+      std::clamp ( physical, 1,
+        static_cast <int> (SK_CPU_Spoof_LogicalProcessors ()) );
+
+    return
+      static_cast <DWORD> (physical);
+  }
+
+  KAFFINITY
+  SK_CPU_Spoof_MaskForCount (DWORD count)
+  {
+    count =
+      std::min (count, SK_CPU_Spoof_MaxLogicalProcessors ());
+
+    if (count == 0)
+      return 0;
+
+    if (count >= SK_CPU_Spoof_MaxLogicalProcessors ())
+      return
+        ~static_cast <KAFFINITY> (0);
+
+    return
+      (static_cast <KAFFINITY> (1) << count) - 1;
+  }
+
+  void
+  SK_CPU_Spoof_LogCall (
+    const wchar_t* api,
+    LPVOID         caller,
+    const wchar_t* details = L"" )
+  {
+    if (! SK_CPU_Spoof_IsEnabled ())
+      return;
+
+    if (! dll_log.isAllocated ())
+      return;
+
+    const HMODULE calling_module =
+      SK_GetCallingDLL (caller);
+
+    if (calling_module == nullptr || calling_module == SK_GetDLL ())
+      return;
+
+    static volatile LONG calls = 0;
+
+    if (InterlockedIncrement (&calls) > 128)
+      return;
+
+    SK_LOGi0 (
+      L"CPU topology spoof: %ws => logical=%lu, physical=%lu%ws%ws [caller=%ws]",
+      api,
+      SK_CPU_Spoof_LogicalProcessors (),
+      SK_CPU_Spoof_PhysicalCores     (),
+      (details != nullptr && *details != L'\0') ? L", " : L"",
+      (details != nullptr) ? details : L"",
+      SK_SummarizeCaller (caller).c_str ()
+    );
+  }
+
+  std::vector <KAFFINITY>
+  SK_CPU_Spoof_CoreMasks (void)
+  {
+    std::vector <KAFFINITY> masks;
+
+    const DWORD logical =
+      SK_CPU_Spoof_LogicalProcessors ();
+
+    const DWORD physical =
+      SK_CPU_Spoof_PhysicalCores ();
+
+    const DWORD base_threads  = logical / physical;
+    const DWORD extra_threads = logical % physical;
+
+    DWORD bit = 0;
+
+    masks.reserve (physical);
+
+    for (DWORD core = 0; core < physical; ++core)
+    {
+      const DWORD threads =
+        std::max (1UL, base_threads + (core < extra_threads ? 1UL : 0UL));
+
+      KAFFINITY mask = 0;
+
+      for (DWORD thread = 0; thread < threads && bit < logical; ++thread, ++bit)
+      {
+        mask |=
+          static_cast <KAFFINITY> (1) << bit;
+      }
+
+      masks.emplace_back (mask);
+    }
+
+    return masks;
+  }
+
+  void
+  SK_CPU_Spoof_AppendProcessorRelationship (
+          std::vector <BYTE>&             out,
+          LOGICAL_PROCESSOR_RELATIONSHIP  relationship,
+          KAFFINITY                       mask )
+  {
+    const DWORD size =
+      FIELD_OFFSET ( SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+                     Processor.GroupMask ) + sizeof (GROUP_AFFINITY);
+
+    std::vector <BYTE> record (size, 0);
+
+    auto* cpu_info =
+      reinterpret_cast <PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX> (
+        record.data ()
+      );
+
+    cpu_info->Relationship             = relationship;
+    cpu_info->Size                     = size;
+    cpu_info->Processor.Flags          =
+      ((mask & (mask - 1)) != 0) ? LTP_PC_SMT : 0;
+    cpu_info->Processor.EfficiencyClass = 0;
+    cpu_info->Processor.GroupCount     = 1;
+    cpu_info->Processor.GroupMask [0].Mask  = mask;
+    cpu_info->Processor.GroupMask [0].Group = 0;
+
+    out.insert (out.end (), record.begin (), record.end ());
+  }
+
+  void
+  SK_CPU_Spoof_AppendNumaRelationship (std::vector <BYTE>& out)
+  {
+    const DWORD size =
+      FIELD_OFFSET ( SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+                     NumaNode.GroupMask ) + sizeof (GROUP_AFFINITY);
+
+    std::vector <BYTE> record (size, 0);
+
+    auto* cpu_info =
+      reinterpret_cast <PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX> (
+        record.data ()
+      );
+
+    cpu_info->Relationship          = RelationNumaNode;
+    cpu_info->Size                  = size;
+    cpu_info->NumaNode.NodeNumber   = 0;
+    cpu_info->NumaNode.GroupMask.Mask  =
+      SK_CPU_Spoof_MaskForCount (SK_CPU_Spoof_LogicalProcessors ());
+    cpu_info->NumaNode.GroupMask.Group = 0;
+
+    out.insert (out.end (), record.begin (), record.end ());
+  }
+
+  void
+  SK_CPU_Spoof_AppendGroupRelationship (std::vector <BYTE>& out)
+  {
+    const DWORD size =
+      FIELD_OFFSET ( SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX,
+                     Group.GroupInfo ) + sizeof (PROCESSOR_GROUP_INFO);
+
+    std::vector <BYTE> record (size, 0);
+
+    auto* cpu_info =
+      reinterpret_cast <PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX> (
+        record.data ()
+      );
+
+    const DWORD logical =
+      SK_CPU_Spoof_LogicalProcessors ();
+
+    cpu_info->Relationship                           = RelationGroup;
+    cpu_info->Size                                   = size;
+    cpu_info->Group.MaximumGroupCount                = 1;
+    cpu_info->Group.ActiveGroupCount                 = 1;
+    cpu_info->Group.GroupInfo [0].MaximumProcessorCount =
+      static_cast <BYTE> (logical);
+    cpu_info->Group.GroupInfo [0].ActiveProcessorCount  =
+      static_cast <BYTE> (logical);
+    cpu_info->Group.GroupInfo [0].ActiveProcessorMask   =
+      SK_CPU_Spoof_MaskForCount (logical);
+
+    out.insert (out.end (), record.begin (), record.end ());
+  }
+
+  std::vector <BYTE>
+  SK_CPU_Spoof_BuildProcessorInformationEx (
+    LOGICAL_PROCESSOR_RELATIONSHIP relationship )
+  {
+    std::vector <BYTE> out;
+
+    if ( relationship != RelationProcessorCore    &&
+         relationship != RelationProcessorPackage &&
+         relationship != RelationNumaNode         &&
+         relationship != RelationGroup            &&
+         relationship != RelationAll )
+    {
+      return out;
+    }
+
+    const KAFFINITY full_mask =
+      SK_CPU_Spoof_MaskForCount (SK_CPU_Spoof_LogicalProcessors ());
+
+    if ( relationship == RelationProcessorCore ||
+         relationship == RelationAll )
+    {
+      for (const KAFFINITY mask : SK_CPU_Spoof_CoreMasks ())
+        SK_CPU_Spoof_AppendProcessorRelationship (
+          out, RelationProcessorCore, mask
+        );
+    }
+
+    if ( relationship == RelationNumaNode ||
+         relationship == RelationAll )
+    {
+      SK_CPU_Spoof_AppendNumaRelationship (out);
+    }
+
+    if ( relationship == RelationProcessorPackage ||
+         relationship == RelationAll )
+    {
+      SK_CPU_Spoof_AppendProcessorRelationship (
+        out, RelationProcessorPackage, full_mask
+      );
+    }
+
+    if ( relationship == RelationGroup ||
+         relationship == RelationAll )
+    {
+      SK_CPU_Spoof_AppendGroupRelationship (out);
+    }
+
+    return out;
+  }
+
+  BOOL
+  SK_CPU_Spoof_CopyBuffer (
+          const std::vector <BYTE>& data,
+          void*                     buffer,
+          PDWORD                    returned_length )
+  {
+    if (returned_length == nullptr)
+    {
+      SetLastError (ERROR_INVALID_PARAMETER);
+      return FALSE;
+    }
+
+    const DWORD required =
+      static_cast <DWORD> (data.size ());
+
+    if (buffer == nullptr || *returned_length < required)
+    {
+      *returned_length = required;
+      SetLastError (ERROR_INSUFFICIENT_BUFFER);
+      return FALSE;
+    }
+
+    memcpy (buffer, data.data (), required);
+
+    *returned_length = required;
+
+    return TRUE;
+  }
+
+  BOOL
+  SK_CPU_Spoof_CopyProcessorInformation (
+          PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer,
+          PDWORD                                returned_length )
+  {
+    if (returned_length == nullptr)
+    {
+      SetLastError (ERROR_INVALID_PARAMETER);
+      return FALSE;
+    }
+
+    const auto masks =
+      SK_CPU_Spoof_CoreMasks ();
+
+    const DWORD record_count =
+      static_cast <DWORD> (masks.size () + 2);
+
+    const DWORD required =
+      record_count * sizeof (SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
+
+    if (buffer == nullptr || *returned_length < required)
+    {
+      *returned_length = required;
+      SetLastError (ERROR_INSUFFICIENT_BUFFER);
+      return FALSE;
+    }
+
+    memset (buffer, 0, required);
+
+    for (size_t i = 0; i < masks.size (); ++i)
+    {
+      buffer [i].ProcessorMask        = masks [i];
+      buffer [i].Relationship         = RelationProcessorCore;
+      buffer [i].ProcessorCore.Flags  =
+        ((masks [i] & (masks [i] - 1)) != 0) ? LTP_PC_SMT : 0;
+    }
+
+    const KAFFINITY full_mask =
+      SK_CPU_Spoof_MaskForCount (SK_CPU_Spoof_LogicalProcessors ());
+
+    buffer [masks.size ()].ProcessorMask       = full_mask;
+    buffer [masks.size ()].Relationship        = RelationNumaNode;
+    buffer [masks.size ()].NumaNode.NodeNumber = 0;
+
+    buffer [masks.size () + 1].ProcessorMask = full_mask;
+    buffer [masks.size () + 1].Relationship  = RelationProcessorPackage;
+
+    *returned_length = required;
+
+    return TRUE;
+  }
+
+  void
+  SK_CPU_Spoof_ApplySystemInfo (LPSYSTEM_INFO info)
+  {
+    if (info == nullptr || ! SK_CPU_Spoof_IsEnabled ())
+      return;
+
+    info->dwActiveProcessorMask =
+      SK_CPU_Spoof_MaskForCount (SK_CPU_Spoof_LogicalProcessors ());
+
+    info->dwNumberOfProcessors =
+      SK_CPU_Spoof_LogicalProcessors ();
+  }
+
+  bool
+  SK_CPU_Spoof_IsGroupZeroOrAll (WORD group_number)
+  {
+    return
+      group_number == 0 || group_number == ALL_PROCESSOR_GROUPS;
+  }
+
+  bool
+  SK_CPU_HookTargetAlreadyQueued (
+    const std::vector <void*>& targets,
+    void*                     target )
+  {
+    return
+      std::find (targets.begin (), targets.end (), target) != targets.end ();
+  }
+
+  MH_STATUS
+  SK_CPU_CreateDLLHook2Unique (
+    const wchar_t*        module,
+    const char*           proc_name,
+    void*                 detour,
+    void**                original,
+    std::vector <void*>&  targets )
+  {
+    void* target =
+      reinterpret_cast <void*> (SK_GetProcAddress (module, proc_name));
+
+    if (target == nullptr)
+      return MH_ERROR_FUNCTION_NOT_FOUND;
+
+    if (SK_CPU_HookTargetAlreadyQueued (targets, target))
+      return MH_OK;
+
+    void* hooked_target = nullptr;
+
+    MH_STATUS status =
+      SK_CreateDLLHook2 (module, proc_name, detour, original, &hooked_target);
+
+    if (status == MH_OK && hooked_target != nullptr)
+      targets.emplace_back (hooked_target);
+
+    return status;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_ParseBool (const wchar_t* value)
+  {
+    return
+      value != nullptr &&
+      ( _wcsicmp (value, L"true") == 0 ||
+        _wcsicmp (value, L"yes")  == 0 ||
+        _wcsicmp (value, L"on")   == 0 ||
+        wcscmp   (value, L"1")    == 0 );
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_ReadConfig (const wchar_t* ini_path)
+  {
+    if (ini_path == nullptr || *ini_path == L'\0')
+      return false;
+
+    if (GetFileAttributesW (ini_path) == INVALID_FILE_ATTRIBUTES)
+      return false;
+
+    wchar_t enabled [32] = { };
+
+    GetPrivateProfileStringW (
+      L"Scheduler.CPUSpoof", L"Enable", L"",
+        enabled, static_cast <DWORD> (std::size (enabled)), ini_path
+    );
+
+    if (! SK_CPU_EarlyTopologySpoof_ParseBool (enabled))
+      return false;
+
+    int logical =
+      GetPrivateProfileIntW (
+        L"Scheduler.CPUSpoof", L"LogicalProcessors", 0, ini_path
+      );
+
+    int physical =
+      GetPrivateProfileIntW (
+        L"Scheduler.CPUSpoof", L"PhysicalCores", 0, ini_path
+      );
+
+    if (logical <= 0 && physical <= 0)
+      return false;
+
+    if (logical <= 0)
+      logical = physical;
+
+    if (physical <= 0)
+      physical = logical;
+
+    logical =
+      std::clamp (logical, 1,
+        static_cast <int> (SK_CPU_Spoof_MaxLogicalProcessors ()));
+
+    physical =
+      std::clamp (physical, 1, logical);
+
+    config.priority.cpu_spoof_enable   = true;
+    config.priority.cpu_spoof_logical  = logical;
+    config.priority.cpu_spoof_physical = physical;
+
+    return true;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_BuildIniPath (
+          const wchar_t* ini_name,
+          wchar_t*       ini_path,
+          size_t         ini_path_count )
+  {
+    const wchar_t* config_path =
+      SK_GetConfigPath ();
+
+    if ( config_path == nullptr || *config_path == L'\0' ||
+         ini_name    == nullptr || *ini_name    == L'\0' ||
+         ini_path    == nullptr ||  ini_path_count == 0 )
+    {
+      return false;
+    }
+
+    if (wcscpy_s (ini_path, ini_path_count, config_path) != 0)
+      return false;
+
+    const size_t len =
+      wcslen (ini_path);
+
+    if ( len > 0 &&
+         ini_path [len - 1] != L'\\' &&
+         ini_path [len - 1] != L'/' )
+    {
+      if (wcscat_s (ini_path, ini_path_count, L"\\") != 0)
+        return false;
+    }
+
+    return
+      wcscat_s (ini_path, ini_path_count, ini_name) == 0;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_BuildProfileIniPath (
+          const wchar_t* profile_name,
+          wchar_t*       ini_path,
+          size_t         ini_path_count )
+  {
+    const wchar_t* install_path =
+      SK_GetInstallPath ();
+
+    if ( install_path  == nullptr || *install_path  == L'\0' ||
+         profile_name  == nullptr || *profile_name  == L'\0' ||
+         ini_path      == nullptr ||  ini_path_count == 0 )
+    {
+      return false;
+    }
+
+    if (wcscpy_s (ini_path, ini_path_count, install_path) != 0)
+      return false;
+
+    const size_t len =
+      wcslen (ini_path);
+
+    if ( len > 0 &&
+         ini_path [len - 1] != L'\\' &&
+         ini_path [len - 1] != L'/' )
+    {
+      if (wcscat_s (ini_path, ini_path_count, L"\\") != 0)
+        return false;
+    }
+
+    return
+      wcscat_s (ini_path, ini_path_count, L"Profiles\\") == 0 &&
+      wcscat_s (ini_path, ini_path_count, profile_name)   == 0 &&
+      wcscat_s (ini_path, ini_path_count, L"\\SpecialK.ini") == 0;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_ReadRegistryProfileConfig (void)
+  {
+    wchar_t app_path [MAX_PATH * 2] = { };
+
+    if (GetModuleFileNameW (nullptr, app_path, MAX_PATH * 2) == 0)
+      return false;
+
+    HKEY profile_key = nullptr;
+
+    if ( RegOpenKeyExW ( HKEY_CURRENT_USER,
+                         LR"(Software\Kaldaien\Special K\Profiles)",
+                         0, KEY_READ, &profile_key ) != ERROR_SUCCESS )
+    {
+      return false;
+    }
+
+    bool found = false;
+
+    wchar_t query_path [MAX_PATH * 2] = { };
+    wcscpy_s (query_path, std::size (query_path), app_path);
+
+    while (*query_path != L'\0')
+    {
+      wchar_t profile_name [MAX_PATH + 2] = { };
+      DWORD   profile_type                = REG_SZ;
+      DWORD   profile_bytes               = sizeof (profile_name);
+
+      if ( RegQueryValueExW ( profile_key, query_path, nullptr,
+                              &profile_type,
+                              reinterpret_cast <LPBYTE> (profile_name),
+                              &profile_bytes ) == ERROR_SUCCESS &&
+           profile_type == REG_SZ &&
+           profile_name [0] != L'\0' )
+      {
+        wchar_t ini_path [MAX_PATH * 2] = { };
+
+        found =
+          SK_CPU_EarlyTopologySpoof_BuildProfileIniPath (
+            profile_name, ini_path, std::size (ini_path)
+          ) &&
+          SK_CPU_EarlyTopologySpoof_ReadConfig (ini_path);
+
+        break;
+      }
+
+      wchar_t* slash =
+        wcsrchr (query_path, L'\\');
+
+      if (slash == nullptr)
+        break;
+
+      *slash = L'\0';
+    }
+
+    RegCloseKey (profile_key);
+
+    return found;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_ReadProfileConfig (void)
+  {
+    wchar_t ini_path [MAX_PATH * 2] = { };
+
+    if ( SK_CPU_EarlyTopologySpoof_BuildIniPath (
+           L"SpecialK.ini", ini_path, std::size (ini_path)
+         ) &&
+         SK_CPU_EarlyTopologySpoof_ReadConfig (ini_path) )
+    {
+      return true;
+    }
+
+    if (SK_CPU_EarlyTopologySpoof_ReadRegistryProfileConfig ())
+      return true;
+
+    wchar_t self_path [MAX_PATH + 2] = { };
+
+    if (GetModuleFileNameW (SK_GetDLL (), self_path, MAX_PATH) == 0)
+      return false;
+
+    const wchar_t* filename =
+      wcsrchr (self_path, L'\\');
+
+    filename =
+      (filename != nullptr) ? filename + 1 : self_path;
+
+    wchar_t module_ini [MAX_PATH + 2] = { };
+
+    if (wcscpy_s (module_ini, std::size (module_ini), filename) != 0)
+      return false;
+
+    if (wchar_t* ext = wcsrchr (module_ini, L'.'); ext != nullptr)
+      *ext = L'\0';
+
+    if ( module_ini [0] == L'\0' ||
+         _wcsicmp (module_ini, L"SpecialK64") == 0 ||
+         _wcsicmp (module_ini, L"SpecialK32") == 0 )
+    {
+      return false;
+    }
+
+    if (wcscat_s (module_ini, std::size (module_ini), L".ini") != 0)
+      return false;
+
+    RtlZeroMemory (ini_path, sizeof (ini_path));
+
+    return
+      SK_CPU_EarlyTopologySpoof_BuildIniPath (
+        module_ini, ini_path, std::size (ini_path)
+      ) &&
+      SK_CPU_EarlyTopologySpoof_ReadConfig (ini_path);
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_PatchLoadedModules (void);
+
+  FARPROC WINAPI
+  SK_CPU_EarlyTopologySpoof_GetProcAddress_Detour (
+    HMODULE hModule,
+    LPCSTR  lpProcName );
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryW_Detour (LPCWSTR lpLibFileName);
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryA_Detour (LPCSTR lpLibFileName);
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryExW_Detour (
+    LPCWSTR lpLibFileName,
+    HANDLE  hFile,
+    DWORD   dwFlags );
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryExA_Detour (
+    LPCSTR lpLibFileName,
+    HANDLE hFile,
+    DWORD  dwFlags );
+
+  void*
+  SK_CPU_EarlyTopologySpoof_DetourForName (
+          const char*  import_name,
+          void***      original )
+  {
+    if (import_name == nullptr || original == nullptr)
+      return nullptr;
+
+    if (_stricmp (import_name, "GetLogicalProcessorInformationEx") == 0)
+    {
+      *original = reinterpret_cast <void**> (
+        &GetLogicalProcessorInformationEx_Original
+      );
+      return reinterpret_cast <void*> (
+        GetLogicalProcessorInformationEx_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "GetLogicalProcessorInformation") == 0)
+    {
+      *original = reinterpret_cast <void**> (
+        &GetLogicalProcessorInformation_Original
+      );
+      return reinterpret_cast <void*> (
+        GetLogicalProcessorInformation_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "GetActiveProcessorCount") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&GetActiveProcessorCount_Original);
+      return reinterpret_cast <void*> (GetActiveProcessorCount_Detour);
+    }
+
+    if (_stricmp (import_name, "GetActiveProcessorGroupCount") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&GetActiveProcessorGroupCount_Original);
+      return reinterpret_cast <void*> (GetActiveProcessorGroupCount_Detour);
+    }
+
+    if (_stricmp (import_name, "GetMaximumProcessorCount") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&GetMaximumProcessorCount_Original);
+      return reinterpret_cast <void*> (GetMaximumProcessorCount_Detour);
+    }
+
+    if (_stricmp (import_name, "GetMaximumProcessorGroupCount") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&GetMaximumProcessorGroupCount_Original);
+      return reinterpret_cast <void*> (GetMaximumProcessorGroupCount_Detour);
+    }
+
+    if (_stricmp (import_name, "GetSystemInfo") == 0)
+    {
+      *original = reinterpret_cast <void**> (&GetSystemInfo_Original);
+      return reinterpret_cast <void*> (GetSystemInfo_Detour);
+    }
+
+    if (_stricmp (import_name, "GetNativeSystemInfo") == 0)
+    {
+      *original = reinterpret_cast <void**> (&GetNativeSystemInfo_Original);
+      return reinterpret_cast <void*> (GetNativeSystemInfo_Detour);
+    }
+
+    if (_stricmp (import_name, "GetProcAddress") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&SK_CPU_Early_GetProcAddress_Original);
+      return reinterpret_cast <void*> (
+        SK_CPU_EarlyTopologySpoof_GetProcAddress_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "LoadLibraryW") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&SK_CPU_Early_LoadLibraryW_Original);
+      return reinterpret_cast <void*> (
+        SK_CPU_EarlyTopologySpoof_LoadLibraryW_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "LoadLibraryA") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&SK_CPU_Early_LoadLibraryA_Original);
+      return reinterpret_cast <void*> (
+        SK_CPU_EarlyTopologySpoof_LoadLibraryA_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "LoadLibraryExW") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&SK_CPU_Early_LoadLibraryExW_Original);
+      return reinterpret_cast <void*> (
+        SK_CPU_EarlyTopologySpoof_LoadLibraryExW_Detour
+      );
+    }
+
+    if (_stricmp (import_name, "LoadLibraryExA") == 0)
+    {
+      *original =
+        reinterpret_cast <void**> (&SK_CPU_Early_LoadLibraryExA_Original);
+      return reinterpret_cast <void*> (
+        SK_CPU_EarlyTopologySpoof_LoadLibraryExA_Detour
+      );
+    }
+
+    return nullptr;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_PatchPointer (
+          void** slot,
+          void*  replacement,
+          void** original )
+  {
+    if (slot == nullptr || replacement == nullptr || *slot == replacement)
+      return false;
+
+    DWORD old_protect = 0;
+
+    if (! VirtualProtect (slot, sizeof (void*), PAGE_READWRITE, &old_protect))
+      return false;
+
+    if (original != nullptr && *original == nullptr)
+      *original = *slot;
+
+    *slot = replacement;
+
+    FlushInstructionCache (GetCurrentProcess (), slot, sizeof (void*));
+
+    DWORD ignored = 0;
+    VirtualProtect (slot, sizeof (void*), old_protect, &ignored);
+
+    return true;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_PatchModuleIAT (HMODULE module)
+  {
+    if (module == nullptr)
+      return false;
+
+    auto* base =
+      reinterpret_cast <BYTE*> (module);
+
+    auto* dos =
+      reinterpret_cast <IMAGE_DOS_HEADER*> (base);
+
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE)
+      return false;
+
+    auto* nt =
+      reinterpret_cast <IMAGE_NT_HEADERS*> (base + dos->e_lfanew);
+
+    if (nt->Signature != IMAGE_NT_SIGNATURE)
+      return false;
+
+    const auto& import_dir =
+      nt->OptionalHeader.DataDirectory [IMAGE_DIRECTORY_ENTRY_IMPORT];
+
+    if (import_dir.VirtualAddress == 0 || import_dir.Size == 0)
+      return false;
+
+    bool patched = false;
+
+    auto* desc =
+      reinterpret_cast <IMAGE_IMPORT_DESCRIPTOR*> (
+        base + import_dir.VirtualAddress
+      );
+
+    for (; desc->Name != 0; ++desc)
+    {
+      if (desc->FirstThunk == 0 || desc->OriginalFirstThunk == 0)
+        continue;
+
+      auto* thunk =
+        reinterpret_cast <IMAGE_THUNK_DATA*> (base + desc->FirstThunk);
+
+      auto* orig =
+        reinterpret_cast <IMAGE_THUNK_DATA*> (base + desc->OriginalFirstThunk);
+
+      for (; orig->u1.AddressOfData != 0 && thunk->u1.Function != 0;
+             ++orig, ++thunk)
+      {
+        if (IMAGE_SNAP_BY_ORDINAL (orig->u1.Ordinal))
+          continue;
+
+        auto* by_name =
+          reinterpret_cast <IMAGE_IMPORT_BY_NAME*> (
+            base + orig->u1.AddressOfData
+          );
+
+        void** original = nullptr;
+        void*  detour   =
+          SK_CPU_EarlyTopologySpoof_DetourForName (
+            reinterpret_cast <const char*> (by_name->Name),
+            &original
+          );
+
+        if (detour == nullptr)
+          continue;
+
+        patched |=
+          SK_CPU_EarlyTopologySpoof_PatchPointer (
+            reinterpret_cast <void**> (&thunk->u1.Function),
+            detour,
+            original
+          );
+      }
+    }
+
+    return patched;
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_IsWindowsModule (const wchar_t* path)
+  {
+    if ( path == nullptr || *path == L'\0' ||
+         SK_CPU_EarlyTopologySpoof_WindowsDir [0] == L'\0' )
+    {
+      return false;
+    }
+
+    const size_t len =
+      wcslen (SK_CPU_EarlyTopologySpoof_WindowsDir);
+
+    return
+      _wcsnicmp (path, SK_CPU_EarlyTopologySpoof_WindowsDir, len) == 0 &&
+      ( path [len] == L'\\' ||
+        path [len] == L'/'  ||
+        path [len] == L'\0' );
+  }
+
+  bool
+  SK_CPU_EarlyTopologySpoof_PatchLoadedModules (void)
+  {
+    if (InterlockedExchange (&SK_CPU_EarlyTopologySpoof_Patching, TRUE) != FALSE)
+      return false;
+
+    bool patched = false;
+
+    HANDLE snapshot =
+      CreateToolhelp32Snapshot (
+        TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32,
+        GetCurrentProcessId ()
+      );
+
+    if (snapshot != INVALID_HANDLE_VALUE)
+    {
+      MODULEENTRY32W entry = { };
+      entry.dwSize = sizeof (entry);
+
+      if (Module32FirstW (snapshot, &entry))
+      {
+        do
+        {
+          if ( entry.hModule != SK_GetDLL () &&
+              !SK_CPU_EarlyTopologySpoof_IsWindowsModule (entry.szExePath) )
+          {
+            patched |=
+              SK_CPU_EarlyTopologySpoof_PatchModuleIAT (entry.hModule);
+          }
+        } while (Module32NextW (snapshot, &entry));
+      }
+
+      CloseHandle (snapshot);
+    }
+
+    InterlockedExchange (&SK_CPU_EarlyTopologySpoof_Patching, FALSE);
+
+    return patched;
+  }
+
+  void
+  SK_CPU_EarlyTopologySpoof_ResolveOriginals (void)
+  {
+    HMODULE kernel32 =
+      GetModuleHandleW (L"kernel32.dll");
+
+    if (kernel32 == nullptr)
+      return;
+
+    auto resolve =
+      [kernel32](const char* proc_name) -> FARPROC
+      {
+        return
+          ::GetProcAddress (kernel32, proc_name);
+      };
+
+    if (GetLogicalProcessorInformationEx_Original == nullptr)
+      GetLogicalProcessorInformationEx_Original =
+        reinterpret_cast <GetLogicalProcessorInformationEx_pfn> (
+          resolve ("GetLogicalProcessorInformationEx")
+        );
+
+    if (GetLogicalProcessorInformation_Original == nullptr)
+      GetLogicalProcessorInformation_Original =
+        reinterpret_cast <GetLogicalProcessorInformation_pfn> (
+          resolve ("GetLogicalProcessorInformation")
+        );
+
+    if (GetActiveProcessorCount_Original == nullptr)
+      GetActiveProcessorCount_Original =
+        reinterpret_cast <GetActiveProcessorCount_pfn> (
+          resolve ("GetActiveProcessorCount")
+        );
+
+    if (GetActiveProcessorGroupCount_Original == nullptr)
+      GetActiveProcessorGroupCount_Original =
+        reinterpret_cast <GetActiveProcessorGroupCount_pfn> (
+          resolve ("GetActiveProcessorGroupCount")
+        );
+
+    if (GetMaximumProcessorCount_Original == nullptr)
+      GetMaximumProcessorCount_Original =
+        reinterpret_cast <GetMaximumProcessorCount_pfn> (
+          resolve ("GetMaximumProcessorCount")
+        );
+
+    if (GetMaximumProcessorGroupCount_Original == nullptr)
+      GetMaximumProcessorGroupCount_Original =
+        reinterpret_cast <GetMaximumProcessorGroupCount_pfn> (
+          resolve ("GetMaximumProcessorGroupCount")
+        );
+
+    if (GetSystemInfo_Original == nullptr)
+      GetSystemInfo_Original =
+        reinterpret_cast <GetSystemInfo_pfn> (
+          resolve ("GetSystemInfo")
+        );
+
+    if (GetNativeSystemInfo_Original == nullptr)
+      GetNativeSystemInfo_Original =
+        reinterpret_cast <GetNativeSystemInfo_pfn> (
+          resolve ("GetNativeSystemInfo")
+        );
+
+    if (SK_CPU_Early_GetProcAddress_Original == nullptr)
+      SK_CPU_Early_GetProcAddress_Original =
+        reinterpret_cast <SK_CPU_Early_GetProcAddress_pfn> (
+          resolve ("GetProcAddress")
+        );
+
+    if (SK_CPU_Early_LoadLibraryW_Original == nullptr)
+      SK_CPU_Early_LoadLibraryW_Original =
+        reinterpret_cast <SK_CPU_Early_LoadLibraryW_pfn> (
+          resolve ("LoadLibraryW")
+        );
+
+    if (SK_CPU_Early_LoadLibraryA_Original == nullptr)
+      SK_CPU_Early_LoadLibraryA_Original =
+        reinterpret_cast <SK_CPU_Early_LoadLibraryA_pfn> (
+          resolve ("LoadLibraryA")
+        );
+
+    if (SK_CPU_Early_LoadLibraryExW_Original == nullptr)
+      SK_CPU_Early_LoadLibraryExW_Original =
+        reinterpret_cast <SK_CPU_Early_LoadLibraryExW_pfn> (
+          resolve ("LoadLibraryExW")
+        );
+
+    if (SK_CPU_Early_LoadLibraryExA_Original == nullptr)
+      SK_CPU_Early_LoadLibraryExA_Original =
+        reinterpret_cast <SK_CPU_Early_LoadLibraryExA_pfn> (
+          resolve ("LoadLibraryExA")
+        );
+  }
+
+  FARPROC WINAPI
+  SK_CPU_EarlyTopologySpoof_GetProcAddress_Detour (
+    HMODULE hModule,
+    LPCSTR  lpProcName )
+  {
+    if (lpProcName != nullptr &&
+        (reinterpret_cast <uintptr_t> (lpProcName) >> 16) != 0)
+    {
+      void** original = nullptr;
+      void*  detour   =
+        SK_CPU_EarlyTopologySpoof_DetourForName (lpProcName, &original);
+
+      if (detour != nullptr)
+        return
+          reinterpret_cast <FARPROC> (detour);
+    }
+
+    return
+      SK_CPU_Early_GetProcAddress_Original != nullptr ?
+        SK_CPU_Early_GetProcAddress_Original (hModule, lpProcName) :
+        nullptr;
+  }
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryW_Detour (LPCWSTR lpLibFileName)
+  {
+    HMODULE module =
+      SK_CPU_Early_LoadLibraryW_Original != nullptr ?
+        SK_CPU_Early_LoadLibraryW_Original (lpLibFileName) :
+        nullptr;
+
+    SK_CPU_EarlyTopologySpoof_PatchLoadedModules ();
+
+    return module;
+  }
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryA_Detour (LPCSTR lpLibFileName)
+  {
+    HMODULE module =
+      SK_CPU_Early_LoadLibraryA_Original != nullptr ?
+        SK_CPU_Early_LoadLibraryA_Original (lpLibFileName) :
+        nullptr;
+
+    SK_CPU_EarlyTopologySpoof_PatchLoadedModules ();
+
+    return module;
+  }
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryExW_Detour (
+    LPCWSTR lpLibFileName,
+    HANDLE  hFile,
+    DWORD   dwFlags )
+  {
+    HMODULE module =
+      SK_CPU_Early_LoadLibraryExW_Original != nullptr ?
+        SK_CPU_Early_LoadLibraryExW_Original (lpLibFileName, hFile, dwFlags) :
+        nullptr;
+
+    SK_CPU_EarlyTopologySpoof_PatchLoadedModules ();
+
+    return module;
+  }
+
+  HMODULE WINAPI
+  SK_CPU_EarlyTopologySpoof_LoadLibraryExA_Detour (
+    LPCSTR lpLibFileName,
+    HANDLE hFile,
+    DWORD  dwFlags )
+  {
+    HMODULE module =
+      SK_CPU_Early_LoadLibraryExA_Original != nullptr ?
+        SK_CPU_Early_LoadLibraryExA_Original (lpLibFileName, hFile, dwFlags) :
+        nullptr;
+
+    SK_CPU_EarlyTopologySpoof_PatchLoadedModules ();
+
+    return module;
+  }
+
+  struct SK_CPU_AppCompatSDB_Writer
+  {
+    std::vector <BYTE> data;
+
+    uint32_t
+    offset (void) const
+    {
+      return
+        static_cast <uint32_t> (data.size ());
+    }
+
+    void
+    u16 (uint16_t value)
+    {
+      data.emplace_back (static_cast <BYTE> ( value        & 0xff));
+      data.emplace_back (static_cast <BYTE> ((value >>  8) & 0xff));
+    }
+
+    void
+    u32 (uint32_t value)
+    {
+      for (int i = 0; i < 4; ++i)
+        data.emplace_back (static_cast <BYTE> ((value >> (i * 8)) & 0xff));
+    }
+
+    void
+    i64 (int64_t value)
+    {
+      const uint64_t bits =
+        static_cast <uint64_t> (value);
+
+      for (int i = 0; i < 8; ++i)
+        data.emplace_back (static_cast <BYTE> ((bits >> (i * 8)) & 0xff));
+    }
+
+    void
+    bytes (const void* ptr, size_t size)
+    {
+      if (ptr == nullptr || size == 0)
+        return;
+
+      const auto* byte_ptr =
+        static_cast <const BYTE*> (ptr);
+
+      data.insert (data.end (), byte_ptr, byte_ptr + size);
+    }
+
+    void
+    list_tag (uint16_t tag, const std::vector <BYTE>& payload)
+    {
+      u16   (tag);
+      u32   (static_cast <uint32_t> (payload.size ()));
+      bytes (payload.data (), payload.size ());
+    }
+
+    void
+    string_ref_tag (uint16_t tag, uint32_t string_ref)
+    {
+      u16 (tag);
+      u32 (string_ref);
+    }
+
+    void
+    dword_tag (uint16_t tag, uint32_t value)
+    {
+      u16 (tag);
+      u32 (value);
+    }
+
+    void
+    qword_tag (uint16_t tag, int64_t value)
+    {
+      u16 (tag);
+      i64 (value);
+    }
+
+    void
+    binary_tag (uint16_t tag, const void* ptr, size_t size)
+    {
+      u16   (tag);
+      u32   (static_cast <uint32_t> (size));
+      bytes (ptr, size);
+    }
+  };
+
+  struct SK_CPU_AppCompatSDB_StringRef
+  {
+    std::wstring value;
+    uint32_t     ref = 0;
+  };
+
+  struct SK_CPU_AppCompatSDB_Game
+  {
+    std::wstring exe;
+    std::wstring app;
+    std::wstring param;
+
+    uint32_t exe_ref             = 0;
+    uint32_t app_ref             = 0;
+    uint32_t param_ref           = 0;
+    uint32_t relative_exe_offset = 0;
+  };
+
+  std::wstring
+  SK_CPU_AppCompatSDB_SanitizeFileName (const std::wstring& name)
+  {
+    std::wstring sanitized = name;
+
+    for (wchar_t& ch : sanitized)
+    {
+      switch (ch)
+      {
+        case L'\\':
+        case L'/':
+        case L':':
+        case L'*':
+        case L'?':
+        case L'"':
+        case L'<':
+        case L'>':
+        case L'|':
+          ch = L'_';
+          break;
+
+        default:
+          break;
+      }
+    }
+
+    return
+      sanitized.empty () ? L"Application" : sanitized;
+  }
+
+  std::wstring
+  SK_CPU_AppCompatSDB_StemFromExe (const std::wstring& exe_name)
+  {
+    std::wstring stem =
+      SK_CPU_AppCompatSDB_SanitizeFileName (exe_name);
+
+    const size_t dot =
+      stem.find_last_of (L'.');
+
+    if (dot != std::wstring::npos && dot > 0)
+      stem.resize (dot);
+
+    return
+      stem;
+  }
+
+  uint32_t
+  SK_CPU_AppCompatSDB_AddString (
+    SK_CPU_AppCompatSDB_Writer&                  writer,
+    std::vector <SK_CPU_AppCompatSDB_StringRef>& refs,
+    const std::wstring&                          value )
+  {
+    for (const auto& ref : refs)
+    {
+      if (ref.value == value)
+        return ref.ref;
+    }
+
+    const uint32_t content_offset =
+      writer.offset () + 6;
+
+    std::vector <BYTE> utf16;
+    utf16.reserve ((value.length () + 1) * sizeof (wchar_t));
+
+    for (wchar_t ch : value)
+    {
+      const uint16_t code_unit =
+        static_cast <uint16_t> (ch);
+
+      utf16.emplace_back (static_cast <BYTE> ( code_unit       & 0xff));
+      utf16.emplace_back (static_cast <BYTE> ((code_unit >> 8) & 0xff));
+    }
+
+    utf16.emplace_back (static_cast <BYTE> (0));
+    utf16.emplace_back (static_cast <BYTE> (0));
+
+    writer.u16   (0x8801);
+    writer.u32   (static_cast <uint32_t> (utf16.size ()));
+    writer.bytes (utf16.data (), utf16.size ());
+
+    refs.emplace_back (SK_CPU_AppCompatSDB_StringRef { value, content_offset });
+
+    return
+      content_offset;
+  }
+
+  uint64_t
+  SK_CPU_AppCompatSDB_HashString (const std::wstring& value, uint64_t seed)
+  {
+    uint64_t hash =
+      1469598103934665603ULL ^ seed;
+
+    for (wchar_t ch : value)
+    {
+      const uint16_t code_unit =
+        static_cast <uint16_t> (::towlower (ch));
+
+      hash ^= ( code_unit       & 0xff);
+      hash *= 1099511628211ULL;
+      hash ^= ((code_unit >> 8) & 0xff);
+      hash *= 1099511628211ULL;
+    }
+
+    return
+      hash;
+  }
+
+  GUID
+  SK_CPU_AppCompatSDB_GuidFor (const std::wstring& exe_name, uint64_t salt)
+  {
+    const uint64_t hash_a =
+      SK_CPU_AppCompatSDB_HashString (exe_name, salt);
+
+    const uint64_t hash_b =
+      SK_CPU_AppCompatSDB_HashString (exe_name, salt ^ 0x9e3779b97f4a7c15ULL);
+
+    GUID guid =
+      { 0x9d09992a, 0x2ca0, 0x4cec,
+        { 0x9e, 0x4e, 0x8d, 0xb4, 0x03, 0x35, 0xcc, 0x2b } };
+
+    guid.Data1 ^= static_cast <DWORD> (hash_a);
+    guid.Data2 ^= static_cast <WORD>  (hash_a >> 32);
+    guid.Data3 ^= static_cast <WORD>  (hash_a >> 48);
+
+    for (int i = 0; i < 8; ++i)
+      guid.Data4 [i] ^=
+        static_cast <BYTE> ((hash_b >> (i * 8)) & 0xff);
+
+    return
+      guid;
+  }
+
+  int64_t
+  SK_CPU_AppCompatSDB_CurrentFileTime (void)
+  {
+    FILETIME file_time = { };
+    GetSystemTimeAsFileTime (&file_time);
+
+    ULARGE_INTEGER large = { };
+    large.LowPart  = file_time.dwLowDateTime;
+    large.HighPart = file_time.dwHighDateTime;
+
+    return
+      static_cast <int64_t> (large.QuadPart);
+  }
+
+  void
+  SK_CPU_AppCompatSDB_WriteGuidTag (
+    SK_CPU_AppCompatSDB_Writer& writer,
+    uint16_t                    tag,
+    const GUID&                 guid )
+  {
+    writer.binary_tag (tag, &guid, sizeof (guid));
+  }
+
+  void
+  SK_CPU_AppCompatSDB_WriteIndexKey (
+    SK_CPU_AppCompatSDB_Writer& writer,
+    const std::wstring&         exe_name )
+  {
+    BYTE key [8] = { };
+
+    for (int i = 0; i < 8; ++i)
+    {
+      wchar_t ch =
+        (i < static_cast <int> (exe_name.length ())) ?
+          ::towupper (exe_name [i]) : L' ';
+
+      key [7 - i] =
+        (ch >= 0 && ch <= 0x7f) ? static_cast <BYTE> (ch) : static_cast <BYTE> ('?');
+    }
+
+    writer.bytes (key, sizeof (key));
+  }
+
+  std::vector <BYTE>
+  SK_CPU_AppCompatSDB_BuildProcessorCountLie (
+    const std::wstring& exe_name,
+    const std::wstring& app_name,
+    int                 processor_count )
+  {
+    std::vector <SK_CPU_AppCompatSDB_Game> games;
+    games.emplace_back ();
+
+    games [0].exe   = exe_name;
+    games [0].app   = app_name.empty () ? SK_CPU_AppCompatSDB_StemFromExe (exe_name) : app_name;
+    games [0].param =
+      std::to_wstring (std::clamp (processor_count, 1, 64));
+
+    SK_CPU_AppCompatSDB_Writer                  strings;
+    std::vector <SK_CPU_AppCompatSDB_StringRef> refs;
+
+    const uint32_t version_ref =
+      SK_CPU_AppCompatSDB_AddString (strings, refs, L"1.0.0.0");
+
+    const uint32_t db_name_ref =
+      SK_CPU_AppCompatSDB_AddString (
+        strings, refs,
+        SK_FormatStringW ( L"Special K AMD AppCompat ProcessorCountLie (%ws)",
+                           exe_name.c_str () )
+      );
+
+    const uint32_t vendor_ref =
+      SK_CPU_AppCompatSDB_AddString (strings, refs, L"<Unknown>");
+
+    const uint32_t match_all_ref =
+      SK_CPU_AppCompatSDB_AddString (strings, refs, L"*");
+
+    const uint32_t shim_ref =
+      SK_CPU_AppCompatSDB_AddString (strings, refs, L"ProcessorCountLie");
+
+    for (auto& game : games)
+    {
+      game.exe_ref =
+        SK_CPU_AppCompatSDB_AddString (strings, refs, game.exe);
+      game.app_ref =
+        SK_CPU_AppCompatSDB_AddString (strings, refs, game.app);
+      game.param_ref =
+        SK_CPU_AppCompatSDB_AddString (strings, refs, game.param);
+    }
+
+    SK_CPU_AppCompatSDB_Writer db;
+    db.qword_tag      (0x5001, SK_CPU_AppCompatSDB_CurrentFileTime ());
+    db.string_ref_tag (0x6022, version_ref);
+    db.string_ref_tag (0x6001, db_name_ref);
+    db.dword_tag      (0x4023, 4);
+    db.dword_tag      (0x4021, 2);
+
+    const GUID database_guid =
+      SK_CPU_AppCompatSDB_GuidFor (exe_name, 0);
+
+    SK_CPU_AppCompatSDB_WriteGuidTag (db, 0x9007, database_guid);
+    db.list_tag (0x7002, { });
+
+    for (size_t i = 0; i < games.size (); ++i)
+    {
+      auto& game =
+        games [i];
+
+      game.relative_exe_offset =
+        db.offset ();
+
+      SK_CPU_AppCompatSDB_Writer exe;
+      exe.string_ref_tag (0x6001, game.exe_ref);
+      exe.string_ref_tag (0x6006, game.app_ref);
+      exe.string_ref_tag (0x6005, vendor_ref);
+
+      const GUID exe_guid =
+        SK_CPU_AppCompatSDB_GuidFor (game.exe, 1 + i);
+      const GUID layer_guid =
+        SK_CPU_AppCompatSDB_GuidFor (game.exe, 0x100 + i);
+
+      SK_CPU_AppCompatSDB_WriteGuidTag (exe, 0x9004, exe_guid);
+      SK_CPU_AppCompatSDB_WriteGuidTag (exe, 0x9011, layer_guid);
+
+      SK_CPU_AppCompatSDB_Writer matching;
+      matching.string_ref_tag (0x6001, match_all_ref);
+      exe.list_tag (0x7008, matching.data);
+
+      SK_CPU_AppCompatSDB_Writer shim;
+      shim.string_ref_tag (0x6001, shim_ref);
+      shim.string_ref_tag (0x6008, game.param_ref);
+      exe.list_tag (0x7009, shim.data);
+
+      db.list_tag (0x7007, exe.data);
+    }
+
+    SK_CPU_AppCompatSDB_Writer index_payload;
+    index_payload.u16       (0x3802);
+    index_payload.u16       (0x7007);
+    index_payload.u16       (0x3803);
+    index_payload.u16       (0x6001);
+    index_payload.dword_tag (0x4016, 1);
+    index_payload.u16       (0x9801);
+    index_payload.u32       (static_cast <uint32_t> (12 * games.size ()));
+
+    const uint32_t index_total_length =
+      12 + (6 + (20 + static_cast <uint32_t> (12 * games.size ()))) + 6;
+
+    const uint32_t database_payload_start =
+      index_total_length + 6;
+
+    for (const auto& game : games)
+    {
+      SK_CPU_AppCompatSDB_WriteIndexKey (index_payload, game.exe);
+      index_payload.u32 (database_payload_start + game.relative_exe_offset);
+    }
+
+    SK_CPU_AppCompatSDB_Writer indexes;
+    indexes.list_tag (0x7803, index_payload.data);
+
+    SK_CPU_AppCompatSDB_Writer root;
+    root.u32 (2);
+    root.u32 (3);
+    root.bytes ("sdbf", 4);
+    root.list_tag (0x7802, indexes.data);
+    root.list_tag (0x7001, db.data);
+    root.list_tag (0x7801, strings.data);
+
+    return
+      root.data;
+  }
+
+  bool
+  SK_CPU_AppCompatSDB_WriteFile (
+    const std::wstring&        path,
+    const std::vector <BYTE>&  data )
+  {
+    if (path.empty () || data.empty ())
+      return false;
+
+    const size_t slash =
+      path.find_last_of (L"\\/");
+
+    if (slash != std::wstring::npos)
+    {
+      const std::wstring dir =
+        path.substr (0, slash + 1);
+
+      SK_CreateDirectoriesEx (dir.c_str (), false);
+    }
+
+    HANDLE hFile =
+      CreateFileW ( path.c_str (), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
+                    FILE_ATTRIBUTE_NORMAL, nullptr );
+
+    if (hFile == INVALID_HANDLE_VALUE)
+      return false;
+
+    DWORD written_total = 0;
+    BOOL  ok            = TRUE;
+
+    while (written_total < data.size () && ok)
+    {
+      DWORD written_now = 0;
+      ok =
+        WriteFile ( hFile, data.data () + written_total,
+                    static_cast <DWORD> (
+                      std::min <size_t> (data.size () - written_total, MAXDWORD)
+                    ),
+                    &written_now, nullptr );
+
+      if (written_now == 0)
+        break;
+
+      written_total +=
+        written_now;
+    }
+
+    CloseHandle (hFile);
+
+    return
+      ok && written_total == data.size ();
+  }
+}
+
+void
+SK_CPU_EarlyTopologySpoof_Install (void)
+{
+  static volatile LONG installed = FALSE;
+
+  if (ReadAcquire (&installed) != FALSE)
+    return;
+
+  if (! SK_CPU_EarlyTopologySpoof_ReadProfileConfig ())
+    return;
+
+  if (InterlockedCompareExchange (&installed, TRUE, FALSE) != FALSE)
+    return;
+
+  GetWindowsDirectoryW (
+    SK_CPU_EarlyTopologySpoof_WindowsDir,
+    static_cast <UINT> (std::size (SK_CPU_EarlyTopologySpoof_WindowsDir))
+  );
+
+  SK_CPU_EarlyTopologySpoof_ResolveOriginals ();
+  SK_CPU_EarlyTopologySpoof_PatchLoadedModules ();
+}
+
+std::wstring
+SK_CPU_AppCompatSDB_GetPath (void)
+{
+  const wchar_t* config_path =
+    SK_GetConfigPath ();
+
+  const wchar_t* host_app =
+    SK_GetHostApp ();
+
+  if (config_path == nullptr || *config_path == L'\0')
+    return { };
+
+  const std::wstring exe_name =
+    (host_app != nullptr && *host_app != L'\0') ? host_app : L"Application.exe";
+
+  return
+    SK_FormatStringW ( LR"(%ws\AppCompat\%ws_CPU_Topology.sdb)",
+                       config_path,
+                       SK_CPU_AppCompatSDB_StemFromExe (exe_name).c_str () );
+}
+
+bool
+SK_CPU_AppCompatSDB_WriteProcessorCountLie (
+  const wchar_t* exe_name,
+  const wchar_t* app_name,
+  int            processor_count,
+  std::wstring*  out_path )
+{
+  const std::wstring resolved_exe =
+    (exe_name != nullptr && *exe_name != L'\0') ? exe_name :
+      (SK_GetHostApp () != nullptr ? SK_GetHostApp () : L"Application.exe");
+
+  const std::wstring resolved_app =
+    (app_name != nullptr) ? app_name : L"";
+
+  const std::wstring sdb_path =
+    SK_CPU_AppCompatSDB_GetPath ();
+
+  if (out_path != nullptr)
+    *out_path = sdb_path;
+
+  if (sdb_path.empty ())
+    return false;
+
+  const auto data =
+    SK_CPU_AppCompatSDB_BuildProcessorCountLie (
+      resolved_exe,
+      resolved_app,
+      processor_count
+    );
+
+  return
+    SK_CPU_AppCompatSDB_WriteFile (sdb_path, data);
+}
+
+bool
+SK_CPU_AppCompatSDB_RunInstaller (
+  const wchar_t* sdb_path,
+  bool           uninstall,
+  bool           update )
+{
+  if (sdb_path == nullptr || *sdb_path == L'\0')
+    return false;
+
+  if (GetFileAttributesW (sdb_path) == INVALID_FILE_ATTRIBUTES)
+    return false;
+
+  wchar_t system_dir [MAX_PATH + 2] = { };
+
+  if (GetSystemDirectoryW (system_dir, MAX_PATH) == 0)
+    return false;
+
+  const std::wstring sdbinst =
+    SK_FormatStringW (LR"(%ws\sdbinst.exe)", system_dir);
+
+  if (GetFileAttributesW (sdbinst.c_str ()) == INVALID_FILE_ATTRIBUTES)
+    return false;
+
+  if (update && ! uninstall)
+  {
+    const std::wstring cmd =
+      SK_FormatStringW (LR"(%ws\cmd.exe)", system_dir);
+
+    const std::wstring params =
+      SK_FormatStringW (
+        LR"(/c ""%ws" -q -u "%ws" >nul 2>nul & "%ws" -q "%ws"")",
+        sdbinst.c_str (), sdb_path, sdbinst.c_str (), sdb_path
+      );
+
+    HINSTANCE hInst =
+      SK_ShellExecuteW (
+        nullptr, L"runas", cmd.c_str (), params.c_str (), nullptr, SW_HIDE
+      );
+
+    return
+      reinterpret_cast <intptr_t> (hInst) > 32;
+  }
+
+  const std::wstring params =
+    uninstall ?
+      SK_FormatStringW (LR"(-q -u "%ws")", sdb_path) :
+      SK_FormatStringW (LR"(-q "%ws")",    sdb_path);
+
+  HINSTANCE hInst =
+    SK_ShellExecuteW (
+      nullptr, L"runas", sdbinst.c_str (), params.c_str (), nullptr, SW_HIDE
+    );
+
+  return
+    reinterpret_cast <intptr_t> (hInst) > 32;
+}
+
 BOOL
 WINAPI
 GetLogicalProcessorInformation_Detour (
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION Buffer,
   PDWORD                                ReturnedLength )
 {
-  SK_LOG_FIRST_CALL
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      const DWORD length_in =
+        (ReturnedLength != nullptr) ? *ReturnedLength : 0UL;
+
+      SK_CPU_Spoof_LogCall (
+        L"GetLogicalProcessorInformation",
+        _ReturnAddress (),
+        SK_FormatStringW (
+          L"buffer=%p, length_in=%lu",
+          Buffer,
+          length_in
+        ).c_str ()
+      );
+    }
+
+    return
+      SK_CPU_Spoof_CopyProcessorInformation (Buffer, ReturnedLength);
+  }
 
   static const
     std::vector <uintptr_t>& pairs =
@@ -108,7 +1952,37 @@ GetLogicalProcessorInformationEx_Detour (
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX Buffer,
   PDWORD                                   ReturnedLength )
 {
-  SK_LOG_FIRST_CALL
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      const DWORD length_in =
+        (ReturnedLength != nullptr) ? *ReturnedLength : 0UL;
+
+      SK_CPU_Spoof_LogCall (
+        L"GetLogicalProcessorInformationEx",
+        _ReturnAddress (),
+        SK_FormatStringW (
+          L"relationship=%d, buffer=%p, length_in=%lu",
+          static_cast <int> (RelationshipType),
+          Buffer,
+          length_in
+        ).c_str ()
+      );
+    }
+
+    auto data =
+      SK_CPU_Spoof_BuildProcessorInformationEx (RelationshipType);
+
+    if (! data.empty ())
+      return
+        SK_CPU_Spoof_CopyBuffer (data, Buffer, ReturnedLength);
+  }
 
   static const
     int core_count =
@@ -284,6 +2158,17 @@ GetSystemInfo_Detour (
 {
   GetSystemInfo_Original (lpSystemInfo);
 
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    SK_CPU_Spoof_LogCall (
+      L"GetSystemInfo",
+      _ReturnAddress ()
+    );
+
+    SK_CPU_Spoof_ApplySystemInfo (lpSystemInfo);
+    return;
+  }
+
   if (config.render.framerate.override_num_cpus == SK_NoPreference)
     return;
 
@@ -295,6 +2180,270 @@ GetSystemInfo_Detour (
   }
 
   lpSystemInfo->dwNumberOfProcessors = config.render.framerate.override_num_cpus;
+}
+
+void
+WINAPI
+GetNativeSystemInfo_Detour (
+  _Out_ LPSYSTEM_INFO lpSystemInfo )
+{
+  if (GetNativeSystemInfo_Original != nullptr)
+    GetNativeSystemInfo_Original (lpSystemInfo);
+  else if (GetSystemInfo_Original != nullptr)
+    GetSystemInfo_Original (lpSystemInfo);
+
+  SK_CPU_Spoof_LogCall (
+    L"GetNativeSystemInfo",
+    _ReturnAddress ()
+  );
+
+  SK_CPU_Spoof_ApplySystemInfo (lpSystemInfo);
+}
+
+DWORD
+WINAPI
+GetActiveProcessorCount_Detour (WORD GroupNumber)
+{
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      SK_CPU_Spoof_LogCall (
+        L"GetActiveProcessorCount",
+        _ReturnAddress (),
+        SK_FormatStringW (L"group=%hu", GroupNumber).c_str ()
+      );
+    }
+
+    return
+      SK_CPU_Spoof_IsGroupZeroOrAll (GroupNumber) ?
+        SK_CPU_Spoof_LogicalProcessors () :
+        0;
+  }
+
+  return
+    GetActiveProcessorCount_Original != nullptr ?
+      GetActiveProcessorCount_Original (GroupNumber) :
+      0;
+}
+
+WORD
+WINAPI
+GetActiveProcessorGroupCount_Detour (void)
+{
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      SK_CPU_Spoof_LogCall (
+        L"GetActiveProcessorGroupCount",
+        _ReturnAddress ()
+      );
+    }
+
+    return 1;
+  }
+
+  return
+    GetActiveProcessorGroupCount_Original != nullptr ?
+      GetActiveProcessorGroupCount_Original () :
+      1;
+}
+
+DWORD
+WINAPI
+GetMaximumProcessorCount_Detour (WORD GroupNumber)
+{
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      SK_CPU_Spoof_LogCall (
+        L"GetMaximumProcessorCount",
+        _ReturnAddress (),
+        SK_FormatStringW (L"group=%hu", GroupNumber).c_str ()
+      );
+    }
+
+    return
+      SK_CPU_Spoof_IsGroupZeroOrAll (GroupNumber) ?
+        SK_CPU_Spoof_LogicalProcessors () :
+        0;
+  }
+
+  return
+    GetMaximumProcessorCount_Original != nullptr ?
+      GetMaximumProcessorCount_Original (GroupNumber) :
+      0;
+}
+
+WORD
+WINAPI
+GetMaximumProcessorGroupCount_Detour (void)
+{
+  if (dll_log.isAllocated ())
+  {
+    SK_LOG_FIRST_CALL
+  }
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    if (dll_log.isAllocated ())
+    {
+      SK_CPU_Spoof_LogCall (
+        L"GetMaximumProcessorGroupCount",
+        _ReturnAddress ()
+      );
+    }
+
+    return 1;
+  }
+
+  return
+    GetMaximumProcessorGroupCount_Original != nullptr ?
+      GetMaximumProcessorGroupCount_Original () :
+      1;
+}
+
+BOOL
+WINAPI
+GetProcessAffinityMask_Detour (
+  _In_  HANDLE     hProcess,
+  _Out_ PDWORD_PTR lpProcessAffinityMask,
+  _Out_ PDWORD_PTR lpSystemAffinityMask )
+{
+  SK_LOG_FIRST_CALL
+
+  const BOOL ret =
+    GetProcessAffinityMask_Original != nullptr ?
+      GetProcessAffinityMask_Original (
+        hProcess,
+        lpProcessAffinityMask,
+        lpSystemAffinityMask
+      ) :
+      FALSE;
+
+  if (ret && SK_CPU_Spoof_IsEnabled ())
+  {
+    const DWORD_PTR mask =
+      static_cast <DWORD_PTR> (
+        SK_CPU_Spoof_MaskForCount (SK_CPU_Spoof_LogicalProcessors ())
+      );
+
+    if (lpProcessAffinityMask != nullptr)
+      *lpProcessAffinityMask = mask;
+
+    if (lpSystemAffinityMask != nullptr)
+      *lpSystemAffinityMask = mask;
+
+    SK_CPU_Spoof_LogCall (
+      L"GetProcessAffinityMask",
+      _ReturnAddress (),
+      SK_FormatStringW (L"mask=%p", reinterpret_cast <void*> (mask)).c_str ()
+    );
+  }
+
+  return ret;
+}
+
+VOID
+WINAPI
+SetThreadpoolThreadMaximum_Detour (
+  _Inout_ PTP_POOL ptpp,
+  _In_    DWORD    cthrdMost )
+{
+  SK_LOG_FIRST_CALL
+
+  DWORD applied_max =
+    cthrdMost;
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    const DWORD logical =
+      SK_CPU_Spoof_LogicalProcessors ();
+
+    if (applied_max == 0 || applied_max > logical)
+      applied_max = logical;
+
+    SK_CPU_Spoof_LogCall (
+      L"SetThreadpoolThreadMaximum",
+      _ReturnAddress (),
+      SK_FormatStringW (L"requested=%lu, applied=%lu", cthrdMost, applied_max).c_str ()
+    );
+  }
+
+  if (SetThreadpoolThreadMaximum_Original != nullptr)
+    SetThreadpoolThreadMaximum_Original (ptpp, applied_max);
+}
+
+BOOL
+WINAPI
+SetThreadpoolThreadMinimum_Detour (
+  _Inout_ PTP_POOL ptpp,
+  _In_    DWORD    cthrdMic )
+{
+  SK_LOG_FIRST_CALL
+
+  DWORD applied_min =
+    cthrdMic;
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    const DWORD logical =
+      SK_CPU_Spoof_LogicalProcessors ();
+
+    if (applied_min > logical)
+      applied_min = logical;
+
+    SK_CPU_Spoof_LogCall (
+      L"SetThreadpoolThreadMinimum",
+      _ReturnAddress (),
+      SK_FormatStringW (L"requested=%lu, applied=%lu", cthrdMic, applied_min).c_str ()
+    );
+  }
+
+  return
+    SetThreadpoolThreadMinimum_Original != nullptr ?
+      SetThreadpoolThreadMinimum_Original (ptpp, applied_min) :
+      FALSE;
+}
+
+unsigned int
+__cdecl
+MSVCP_Thrd_hardware_concurrency_Detour (void)
+{
+  SK_LOG_FIRST_CALL
+
+  if (SK_CPU_Spoof_IsEnabled ())
+  {
+    SK_CPU_Spoof_LogCall (
+      L"MSVCP140!_Thrd_hardware_concurrency",
+      _ReturnAddress ()
+    );
+
+    return
+      static_cast <unsigned int> (SK_CPU_Spoof_LogicalProcessors ());
+  }
+
+  return
+    MSVCP_Thrd_hardware_concurrency_Original != nullptr ?
+      MSVCP_Thrd_hardware_concurrency_Original () :
+      0U;
 }
 
 void
@@ -317,20 +2466,97 @@ SK_CPU_InstallHooks (void)
 {
   SK_PROFILE_FIRST_CALL
 
-  SK_CreateDLLHook2 (      L"Kernel32",
-                            "GetLogicalProcessorInformation",
-                             GetLogicalProcessorInformation_Detour,
-    static_cast_p2p <void> (&GetLogicalProcessorInformation_Original) );
+  static std::vector <void*> hooked_targets;
 
-  SK_CreateDLLHook2 (      L"Kernel32",
-                            "GetLogicalProcessorInformationEx",
-                             GetLogicalProcessorInformationEx_Detour,
-    static_cast_p2p <void> (&GetLogicalProcessorInformationEx_Original) );
+  for (const wchar_t* module : { L"Kernel32", L"KernelBase" })
+  {
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetLogicalProcessorInformation",
+      GetLogicalProcessorInformation_Detour,
+      static_cast_p2p <void> (&GetLogicalProcessorInformation_Original),
+      hooked_targets
+    );
 
-  SK_CreateDLLHook2 (     L"Kernel32",
-                            "GetSystemInfo",
-                             GetSystemInfo_Detour,
-    static_cast_p2p <void> (&GetSystemInfo_Original) );
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetLogicalProcessorInformationEx",
+      GetLogicalProcessorInformationEx_Detour,
+      static_cast_p2p <void> (&GetLogicalProcessorInformationEx_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetSystemInfo",
+      GetSystemInfo_Detour,
+      static_cast_p2p <void> (&GetSystemInfo_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetNativeSystemInfo",
+      GetNativeSystemInfo_Detour,
+      static_cast_p2p <void> (&GetNativeSystemInfo_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetActiveProcessorCount",
+      GetActiveProcessorCount_Detour,
+      static_cast_p2p <void> (&GetActiveProcessorCount_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetActiveProcessorGroupCount",
+      GetActiveProcessorGroupCount_Detour,
+      static_cast_p2p <void> (&GetActiveProcessorGroupCount_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetMaximumProcessorCount",
+      GetMaximumProcessorCount_Detour,
+      static_cast_p2p <void> (&GetMaximumProcessorCount_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetMaximumProcessorGroupCount",
+      GetMaximumProcessorGroupCount_Detour,
+      static_cast_p2p <void> (&GetMaximumProcessorGroupCount_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "GetProcessAffinityMask",
+      GetProcessAffinityMask_Detour,
+      static_cast_p2p <void> (&GetProcessAffinityMask_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "SetThreadpoolThreadMaximum",
+      SetThreadpoolThreadMaximum_Detour,
+      static_cast_p2p <void> (&SetThreadpoolThreadMaximum_Original),
+      hooked_targets
+    );
+
+    SK_CPU_CreateDLLHook2Unique (
+      module, "SetThreadpoolThreadMinimum",
+      SetThreadpoolThreadMinimum_Detour,
+      static_cast_p2p <void> (&SetThreadpoolThreadMinimum_Original),
+      hooked_targets
+    );
+  }
+
+  if (GetModuleHandleW (L"MSVCP140.dll") != nullptr)
+  {
+    SK_CPU_CreateDLLHook2Unique (
+      L"MSVCP140.dll", "_Thrd_hardware_concurrency",
+      MSVCP_Thrd_hardware_concurrency_Detour,
+      static_cast_p2p <void> (&MSVCP_Thrd_hardware_concurrency_Original),
+      hooked_targets
+    );
+  }
 }
 
 

--- a/src/diagnostics/debug_utils.cpp
+++ b/src/diagnostics/debug_utils.cpp
@@ -1677,6 +1677,85 @@ NtCreateThreadEx_pfn         ZwCreateThreadEx_Original       = nullptr;
 NtSetInformationThread_pfn   NtSetInformationThread_Original = nullptr;
 ZwSetInformationThread_pfn   ZwSetInformationThread_Original = nullptr;
 
+using CreateThread_pfn =
+  HANDLE (WINAPI *)( LPSECURITY_ATTRIBUTES   lpThreadAttributes,
+                     SIZE_T                  dwStackSize,
+                     LPTHREAD_START_ROUTINE  lpStartAddress,
+                     LPVOID                  lpParameter,
+                     DWORD                   dwCreationFlags,
+                     LPDWORD                 lpThreadId );
+
+using CreateRemoteThreadEx_pfn =
+  HANDLE (WINAPI *)( HANDLE                       hProcess,
+                     LPSECURITY_ATTRIBUTES       lpThreadAttributes,
+                     SIZE_T                      dwStackSize,
+                     LPTHREAD_START_ROUTINE      lpStartAddress,
+                     LPVOID                      lpParameter,
+                     DWORD                       dwCreationFlags,
+                     LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+                     LPDWORD                     lpThreadId );
+
+static CreateThread_pfn         CreateThread_Original         = nullptr;
+static CreateRemoteThreadEx_pfn CreateRemoteThreadEx_Original = nullptr;
+
+struct SK_CPU_Spoof_ThreadCreateInfo
+{
+  DWORD order = 0;
+  PVOID start = nullptr;
+  PVOID argument = nullptr;
+  wchar_t api      [32]  = { };
+  wchar_t start_mod[64]  = { };
+  wchar_t arg_name [64]  = { };
+  wchar_t caller   [256] = { };
+};
+
+static SK_LazyGlobal <
+  concurrency::concurrent_unordered_map <DWORD, SK_CPU_Spoof_ThreadCreateInfo>
+> SK_CPU_Spoof_ThreadCreates;
+
+static volatile LONG SK_CPU_Spoof_ThreadCreateOrder = 0;
+
+void
+SK_CPU_Spoof_OnThreadNameObserved ( DWORD          dwTid,
+                                    const wchar_t* name,
+                                    const wchar_t* source,
+                                    LPVOID         caller );
+
+static bool
+SK_CPU_Spoof_CopyThreadNameInformation ( const UNICODE_STRING_SK* thread_name,
+                                         wchar_t*                 name,
+                                         size_t                   name_cch )
+{
+  if (thread_name == nullptr || name == nullptr || name_cch == 0)
+    return false;
+
+  *name = L'\0';
+
+  __try
+  {
+    if ( thread_name->Buffer == nullptr ||
+         thread_name->Length < sizeof (wchar_t) )
+      return false;
+
+    const size_t cch =
+      std::min <size_t> (
+        thread_name->Length / sizeof (wchar_t),
+        name_cch - 1
+      );
+
+    wcsncpy_s (name, name_cch, thread_name->Buffer, cch);
+  }
+
+  __except (EXCEPTION_EXECUTE_HANDLER)
+  {
+    *name = L'\0';
+    return false;
+  }
+
+  return
+    *name != L'\0';
+}
+
 static RtlAcquirePebLock_pfn RtlAcquirePebLock_Original      = nullptr;
 static RtlReleasePebLock_pfn RtlReleasePebLock_Original      = nullptr;
 
@@ -1952,6 +2031,53 @@ ZwSetInformationThread_Detour (
 {
   SK_LOG_FIRST_CALL
 
+  if ( config.priority.cpu_spoof_enable &&
+       ThreadInformationClass == ThreadNameInformation_ &&
+       ThreadInformation != nullptr &&
+       ThreadInformationLength >= sizeof (UNICODE_STRING_SK) )
+  {
+    SK_AutoHandle hDuplicate (INVALID_HANDLE_VALUE);
+
+    HANDLE hNameThread =
+      ThreadHandle;
+
+    if ((LONG_PTR)hNameThread == -2)
+    {
+      if (
+        DuplicateHandle ( SK_GetCurrentProcess (),
+                          SK_GetCurrentThread  (),
+                          SK_GetCurrentProcess (),
+                            &hDuplicate.m_h,
+                              THREAD_QUERY_LIMITED_INFORMATION, FALSE,
+                          0 )
+         )
+      {
+        hNameThread = hDuplicate.m_h;
+      }
+    }
+
+    const DWORD dwTid =
+      hNameThread != nullptr ? GetThreadId (hNameThread) : 0;
+
+    wchar_t name [SK_MAX_THREAD_NAME_LEN] = { };
+
+    if ( dwTid != 0 &&
+         SK_CPU_Spoof_CopyThreadNameInformation (
+           static_cast <const UNICODE_STRING_SK *> (ThreadInformation),
+           name,
+           std::size (name)
+         )
+       )
+    {
+      SK_CPU_Spoof_OnThreadNameObserved (
+        dwTid,
+        name,
+        L"ZwSetInformationThread(ThreadNameInformation)",
+        _ReturnAddress ()
+      );
+    }
+  }
+
   if ( ThreadInformationClass == ThreadZeroTlsCell ||
        ThreadInformationClass == ThreadSetTlsArrayAddress )
   {
@@ -2082,6 +2208,446 @@ SK_Thread_NotifyCreation (HANDLE  ThreadHandle,
   }
 }
 
+static bool
+SK_CPU_Spoof_CopyAsciiThreadArgName ( const char* s,
+                                      wchar_t*    out,
+                                      size_t      out_cch )
+{
+  if (s == nullptr || out == nullptr || out_cch == 0)
+    return false;
+
+  char narrow [64] = { };
+
+  __try
+  {
+    size_t i = 0;
+
+    for ( ; i < std::min <size_t> (std::size (narrow) - 1, out_cch - 1); ++i)
+    {
+      const char ch = s [i];
+
+      if (ch == '\0')
+        break;
+
+      if (static_cast <unsigned char> (ch) < 0x20 ||
+          static_cast <unsigned char> (ch) > 0x7e)
+        return false;
+
+      narrow [i] = ch;
+    }
+
+    if (i == 0)
+      return false;
+  }
+
+  __except (EXCEPTION_EXECUTE_HANDLER)
+  {
+    return false;
+  }
+
+  MultiByteToWideChar (
+    CP_UTF8, 0, narrow, -1, out,
+    gsl::narrow_cast <int> (out_cch)
+  );
+
+  return true;
+}
+
+static bool
+SK_CPU_Spoof_CopyWideThreadArgName ( const wchar_t* s,
+                                     wchar_t*       out,
+                                     size_t         out_cch )
+{
+  if (s == nullptr || out == nullptr || out_cch == 0)
+    return false;
+
+  __try
+  {
+    size_t i = 0;
+
+    for ( ; i < out_cch - 1; ++i)
+    {
+      const wchar_t ch = s [i];
+
+      if (ch == L'\0')
+        break;
+
+      if (ch < 0x20 || ch > 0x7e)
+        return false;
+
+      out [i] = ch;
+    }
+
+    if (i == 0)
+      return false;
+
+    out [i] = L'\0';
+  }
+
+  __except (EXCEPTION_EXECUTE_HANDLER)
+  {
+    return false;
+  }
+
+  return true;
+}
+
+static bool
+SK_CPU_Spoof_FindThreadArgName ( PVOID    Argument,
+                                 wchar_t* out,
+                                 size_t   out_cch )
+{
+  if (Argument == nullptr || out == nullptr || out_cch == 0)
+    return false;
+
+  *out = L'\0';
+
+  auto has_ascii_prefix = [](const char* s, const char* prefix) -> bool
+  {
+    __try
+    {
+      for (size_t i = 0; prefix [i] != '\0'; ++i)
+        if (s [i] != prefix [i])
+          return false;
+
+      return true;
+    }
+
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+      return false;
+    }
+  };
+
+  auto has_wide_prefix = [](const wchar_t* s, const wchar_t* prefix) -> bool
+  {
+    __try
+    {
+      for (size_t i = 0; prefix [i] != L'\0'; ++i)
+        if (s [i] != prefix [i])
+          return false;
+
+      return true;
+    }
+
+    __except (EXCEPTION_EXECUTE_HANDLER)
+    {
+      return false;
+    }
+  };
+
+  const auto* bytes =
+    static_cast <const uint8_t *> (Argument);
+
+  for (size_t offset = 0; offset < 0x400; ++offset)
+  {
+    const char* s =
+      reinterpret_cast <const char *> (bytes + offset);
+
+    if (has_ascii_prefix (s, "Worker ") ||
+        has_ascii_prefix (s, "SystemFileDevice"))
+    {
+      return
+        SK_CPU_Spoof_CopyAsciiThreadArgName (s, out, out_cch);
+    }
+
+    const wchar_t* ws =
+      reinterpret_cast <const wchar_t *> (bytes + offset);
+
+    if (has_wide_prefix (ws, L"Worker ") ||
+        has_wide_prefix (ws, L"SystemFileDevice"))
+    {
+      return
+        SK_CPU_Spoof_CopyWideThreadArgName (ws, out, out_cch);
+    }
+  }
+
+  return false;
+}
+
+static DWORD
+SK_CPU_Spoof_WorkerCap (void)
+{
+  int cap =
+    config.priority.cpu_spoof_logical;
+
+  if (cap <= 0)
+    return 0;
+
+  return
+    static_cast <DWORD> (std::clamp (cap, 1, 64));
+}
+
+static bool
+SK_CPU_Spoof_ParseWorkerName ( const wchar_t* name,
+                               DWORD*         worker_num )
+{
+  if (name == nullptr || worker_num == nullptr)
+    return false;
+
+  DWORD num = 0;
+
+  if (swscanf_s (name, L"Worker %lu", &num) != 1)
+    return false;
+
+  *worker_num = num;
+
+  return true;
+}
+
+static void
+SK_CPU_Spoof_LogThreadCreation ( const wchar_t* api,
+                                 HANDLE         ThreadHandle,
+                                 DWORD          ThreadId,
+                                 PVOID          StartRoutine,
+                                 PVOID          Argument,
+                                 HMODULE        hModStart,
+                                 LPVOID         Caller,
+                                 ULONG          CreateFlagsIn,
+                                 ULONG          CreateFlagsOut,
+                                 SIZE_T         StackSize,
+                                 SIZE_T         MaximumStackSize )
+{
+  if (! config.priority.cpu_spoof_enable)
+    return;
+
+  const HMODULE hCaller =
+    SK_GetCallingDLL (Caller);
+
+  if (hCaller == nullptr || hCaller == SK_GetDLL ())
+    return;
+
+  const HMODULE hHost =
+    SK_GetModuleHandle (nullptr);
+
+  const bool start_valid =
+    hModStart != nullptr && hModStart != INVALID_HANDLE_VALUE;
+
+  const std::wstring caller_name =
+    SK_GetModuleName (hCaller);
+
+  const std::wstring start_name =
+    start_valid ? SK_GetModuleName (hModStart) : L"#Invalid.dll#";
+
+  wchar_t arg_name [64] = { };
+
+  SK_CPU_Spoof_FindThreadArgName (Argument, arg_name, std::size (arg_name));
+
+  const bool interesting =
+    hCaller   == hHost ||
+    hModStart == hHost ||
+    arg_name [0] != L'\0';
+
+  if (! interesting)
+    return;
+
+  if (ThreadId != 0)
+  {
+    SK_CPU_Spoof_ThreadCreateInfo info = { };
+
+    info.order =
+      static_cast <DWORD> (InterlockedIncrement (&SK_CPU_Spoof_ThreadCreateOrder));
+    info.start    = StartRoutine;
+    info.argument = Argument;
+
+    wcsncpy_s (info.api,       api,                _TRUNCATE);
+    wcsncpy_s (info.start_mod, start_name.c_str (), _TRUNCATE);
+    wcsncpy_s (info.arg_name,  arg_name,            _TRUNCATE);
+    wcsncpy_s (info.caller,    SK_SummarizeCaller (Caller).c_str (), _TRUNCATE);
+
+    SK_CPU_Spoof_ThreadCreates.get ()[ThreadId] = info;
+  }
+
+  static volatile LONG thread_create_logs = 0;
+
+  if (InterlockedIncrement (&thread_create_logs) > 256)
+    return;
+
+  SK_LOGi0 (
+    L"CPU topology spoof: %ws created thread => tid=0x%04x, handle=%p, start=%p (%ws), arg=%p%ws%ws%ws, flags_in=0x%08x, flags_out=0x%08x, stack=%llu/%llu [caller=%ws]",
+    api,
+    ThreadId,
+    ThreadHandle,
+    StartRoutine,
+    start_name.c_str (),
+    Argument,
+    arg_name [0] != L'\0' ? L", arg_name=\"" : L"",
+    arg_name [0] != L'\0' ? arg_name         : L"",
+    arg_name [0] != L'\0' ? L"\""            : L"",
+    CreateFlagsIn,
+    CreateFlagsOut,
+    static_cast <unsigned long long> (StackSize),
+    static_cast <unsigned long long> (MaximumStackSize),
+    SK_SummarizeCaller (Caller).c_str ()
+  );
+}
+
+void
+SK_CPU_Spoof_OnThreadNameObserved ( DWORD          dwTid,
+                                    const wchar_t* name,
+                                    const wchar_t* source,
+                                    LPVOID         caller )
+{
+  if (! config.priority.cpu_spoof_enable)
+    return;
+
+  DWORD worker_num = 0;
+
+  if (! SK_CPU_Spoof_ParseWorkerName (name, &worker_num))
+    return;
+
+  static volatile LONG worker_name_logs = 0;
+
+  if (InterlockedIncrement (&worker_name_logs) > 512)
+    return;
+
+  auto& creates =
+    SK_CPU_Spoof_ThreadCreates.get ();
+
+  auto it =
+    creates.find (dwTid);
+
+  const DWORD cap =
+    SK_CPU_Spoof_WorkerCap ();
+
+  const wchar_t* source_name =
+    source != nullptr ? source : L"unknown";
+
+  if (it != creates.cend ())
+  {
+    const auto& create =
+      it->second;
+
+    SK_LOGi0 (
+      L"CPU topology spoof: worker name observed via %ws => worker=%lu, cap=%lu, tid=0x%04x, create_order=%lu, start=%p (%ws), arg=%p%ws%ws%ws [create_api=%ws, create_caller=%ws, name_caller=%ws]",
+      source_name,
+      worker_num,
+      cap,
+      dwTid,
+      create.order,
+      create.start,
+      create.start_mod,
+      create.argument,
+      create.arg_name [0] != L'\0' ? L", arg_name=\"" : L"",
+      create.arg_name [0] != L'\0' ? create.arg_name  : L"",
+      create.arg_name [0] != L'\0' ? L"\""            : L"",
+      create.api,
+      create.caller,
+      caller != nullptr ? SK_SummarizeCaller (caller).c_str () : L"<unknown>"
+    );
+  }
+
+  else
+  {
+    SK_LOGi0 (
+      L"CPU topology spoof: worker name observed via %ws => worker=%lu, cap=%lu, tid=0x%04x, no create record [name_caller=%ws]",
+      source_name,
+      worker_num,
+      cap,
+      dwTid,
+      caller != nullptr ? SK_SummarizeCaller (caller).c_str () : L"<unknown>"
+    );
+  }
+}
+
+HANDLE
+WINAPI
+CreateThread_Detour ( LPSECURITY_ATTRIBUTES  lpThreadAttributes,
+                      SIZE_T                 dwStackSize,
+                      LPTHREAD_START_ROUTINE lpStartAddress,
+                      LPVOID                 lpParameter,
+                      DWORD                  dwCreationFlags,
+                      LPDWORD                lpThreadId )
+{
+  SK_LOG_FIRST_CALL
+
+  LPVOID caller =
+    _ReturnAddress ();
+
+  HANDLE hThread =
+    CreateThread_Original (
+      lpThreadAttributes,
+      dwStackSize,
+      lpStartAddress,
+      lpParameter,
+      dwCreationFlags,
+      lpThreadId
+    );
+
+  if (hThread != nullptr)
+  {
+    const DWORD tid =
+      lpThreadId != nullptr ? *lpThreadId : GetThreadId (hThread);
+
+    SK_CPU_Spoof_LogThreadCreation (
+      L"CreateThread",
+      hThread,
+      tid,
+      reinterpret_cast <PVOID> (lpStartAddress),
+      lpParameter,
+      SK_GetModuleFromAddr (reinterpret_cast <PVOID> (lpStartAddress)),
+      caller,
+      dwCreationFlags,
+      dwCreationFlags,
+      dwStackSize,
+      0
+    );
+  }
+
+  return hThread;
+}
+
+HANDLE
+WINAPI
+CreateRemoteThreadEx_Detour ( HANDLE                       hProcess,
+                              LPSECURITY_ATTRIBUTES       lpThreadAttributes,
+                              SIZE_T                      dwStackSize,
+                              LPTHREAD_START_ROUTINE      lpStartAddress,
+                              LPVOID                      lpParameter,
+                              DWORD                       dwCreationFlags,
+                              LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList,
+                              LPDWORD                     lpThreadId )
+{
+  SK_LOG_FIRST_CALL
+
+  LPVOID caller =
+    _ReturnAddress ();
+
+  HANDLE hThread =
+    CreateRemoteThreadEx_Original (
+      hProcess,
+      lpThreadAttributes,
+      dwStackSize,
+      lpStartAddress,
+      lpParameter,
+      dwCreationFlags,
+      lpAttributeList,
+      lpThreadId
+    );
+
+  if (hThread != nullptr)
+  {
+    const DWORD tid =
+      lpThreadId != nullptr ? *lpThreadId : GetThreadId (hThread);
+
+    SK_CPU_Spoof_LogThreadCreation (
+      L"CreateRemoteThreadEx",
+      hThread,
+      tid,
+      reinterpret_cast <PVOID> (lpStartAddress),
+      lpParameter,
+      SK_GetModuleFromAddr (reinterpret_cast <PVOID> (lpStartAddress)),
+      caller,
+      dwCreationFlags,
+      dwCreationFlags,
+      dwStackSize,
+      0
+    );
+  }
+
+  return hThread;
+}
+
 
 NTSTATUS
 NTAPI
@@ -2099,6 +2665,12 @@ ZwCreateThreadEx_Detour (
   _In_opt_ PVOID              AttributeList )
 {
   SK_LOG_FIRST_CALL
+
+  const ULONG create_flags_in =
+    CreateFlags;
+
+  LPVOID caller =
+    _ReturnAddress ();
 
   ULONG ulLen = 0;
 
@@ -2254,6 +2826,20 @@ ZwCreateThreadEx_Detour (
       ResumeThread (*ThreadHandle);
     }
 
+    SK_CPU_Spoof_LogThreadCreation (
+      L"ZwCreateThreadEx",
+      *ThreadHandle,
+      tid,
+      StartRoutine,
+      Argument,
+      hModStart,
+      caller,
+      create_flags_in,
+      CreateFlags,
+      StackSize,
+      MaximumStackSize
+    );
+
     SK_Thread_NotifyCreation (*ThreadHandle, tid, StartRoutine, hModStart);
   }
 
@@ -2276,6 +2862,12 @@ NtCreateThreadEx_Detour (
   _In_opt_ PVOID                AttributeList )
 {
   SK_LOG_FIRST_CALL
+
+  const ULONG create_flags_in =
+    CreateFlags;
+
+  LPVOID caller =
+    _ReturnAddress ();
 
   ULONG ulLen = 0;
 
@@ -2432,6 +3024,20 @@ NtCreateThreadEx_Detour (
     {
       ResumeThread (*ThreadHandle);
     }
+
+    SK_CPU_Spoof_LogThreadCreation (
+      L"NtCreateThreadEx",
+      *ThreadHandle,
+      tid,
+      StartRoutine,
+      Argument,
+      hModStart,
+      caller,
+      create_flags_in,
+      CreateFlags,
+      StackSize,
+      MaximumStackSize
+    );
   }
 
   return ret;
@@ -2888,6 +3494,58 @@ SK_Exception_HandleThreadName (
       std::wstring wide_name (
         SK_UTF8ToWideChar (info->szName).c_str ()
       );
+
+      DWORD worker_num = 0;
+
+      if ( config.priority.cpu_spoof_enable &&
+           SK_CPU_Spoof_ParseWorkerName (wide_name.c_str (), &worker_num) )
+      {
+        static volatile LONG worker_name_logs = 0;
+
+        if (InterlockedIncrement (&worker_name_logs) <= 256)
+        {
+          auto& creates =
+            SK_CPU_Spoof_ThreadCreates.get ();
+
+          auto it =
+            creates.find (dwTid);
+
+          const DWORD cap =
+            SK_CPU_Spoof_WorkerCap ();
+
+          if (it != creates.cend ())
+          {
+            const auto& create =
+              it->second;
+
+            SK_LOGi0 (
+              L"CPU topology spoof: worker name exception => worker=%lu, cap=%lu, tid=0x%04x, create_order=%lu, start=%p (%ws), arg=%p%ws%ws%ws [create_api=%ws, create_caller=%ws]",
+              worker_num,
+              cap,
+              dwTid,
+              create.order,
+              create.start,
+              create.start_mod,
+              create.argument,
+              create.arg_name [0] != L'\0' ? L", arg_name=\"" : L"",
+              create.arg_name [0] != L'\0' ? create.arg_name  : L"",
+              create.arg_name [0] != L'\0' ? L"\""            : L"",
+              create.api,
+              create.caller
+            );
+          }
+
+          else
+          {
+            SK_LOGi0 (
+              L"CPU topology spoof: worker name exception => worker=%lu, cap=%lu, tid=0x%04x, no create record",
+              worker_num,
+              cap,
+              dwTid
+            );
+          }
+        }
+      }
 
       if (pTLS != nullptr)
       {
@@ -4003,6 +4661,16 @@ SK::Diagnostics::Debugger::Allow  (bool bAllow)
                                ZwCreateThreadEx_Detour,
       static_cast_p2p <void> (&ZwCreateThreadEx_Original) );
 #endif
+
+    SK_CreateDLLHook2 (      L"Kernel32",
+                              "CreateThread",
+                               CreateThread_Detour,
+      static_cast_p2p <void> (&CreateThread_Original) );
+
+    SK_CreateDLLHook2 (      L"KernelBase",
+                              "CreateRemoteThreadEx",
+                               CreateRemoteThreadEx_Detour,
+      static_cast_p2p <void> (&CreateRemoteThreadEx_Original) );
 
     SK_CreateDLLHook2 (      L"NtDll",
                               "ZwSetInformationThread",

--- a/src/performance/io_monitor.cpp
+++ b/src/performance/io_monitor.cpp
@@ -427,7 +427,8 @@ SK_MonitorCPU (LPVOID user_param)
   SK_GetSystemInfo (&si);
 
   cpu.num_cpus =
-    si.dwNumberOfProcessors;
+    std::min <DWORD> ( si.dwNumberOfProcessors,
+      static_cast <DWORD> (_countof (cpu.cpus) - 1) );
 
   static ULONG ulAllocatedPerfBytes =
       cpu.num_cpus * sizeof (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION__SK);
@@ -471,12 +472,18 @@ SK_MonitorCPU (LPVOID user_param)
       bool needs_idle_fixup = false;
 
       const int count =
-        ( ulAllocatedPerfBytes / sizeof (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION__SK) );
+        std::min <int> (
+          ( ulAllocatedPerfBytes / sizeof (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION__SK) ),
+          static_cast <int> (_countof (cpu.cpus) - 1)
+        );
 
       PSYSTEM_PROCESSOR_PERFORMANCE_INFORMATION__SK pCPU    =  pPerformance,
                                                     pEndCPU = &pCPU [count];
 
-      assert (count < 64);
+      assert (count <= static_cast <int> (_countof (cpu.cpus) - 1));
+
+      cpu.num_cpus =
+        static_cast <DWORD> (count);
 
       cpu.beginNewAggregate ();
       {

--- a/src/plugins/unclassified.cpp
+++ b/src/plugins/unclassified.cpp
@@ -754,15 +754,28 @@ SK_POE2_PlugInCfg (void)
 
     ImGui::Separator ();
 
-    static int orig =
-      config.render.framerate.override_num_cpus;
+    static bool orig_spoof =
+      config.priority.cpu_spoof_enable;
 
-    bool spoof = (config.render.framerate.override_num_cpus != SK_NoPreference);
+    static int orig_logical =
+      config.priority.cpu_spoof_logical;
+
+    static int orig_physical =
+      config.priority.cpu_spoof_physical;
+
+    bool spoof =
+      config.priority.cpu_spoof_enable;
 
     static SYSTEM_INFO             si = { };
     SK_RunOnce (SK_GetSystemInfo (&si));
 
-    if ((! spoof) || sk::narrow_cast <DWORD> (config.render.framerate.override_num_cpus) > (si.dwNumberOfProcessors / 2))
+    const int max_spoofed_processors =
+      static_cast <int> (std::max (1UL, si.dwNumberOfProcessors));
+
+    const int suggested_processors =
+      std::max (1, max_spoofed_processors / 2);
+
+    if ((! spoof) || config.priority.cpu_spoof_logical > suggested_processors)
     {
       ImGui::PushStyleColor (ImGuiCol_Text, (ImVec4&&)ImColor::HSV (.14f, .8f, .9f));
       ImGui::BulletText     ("It is strongly suggested that you reduce worker threads to 1/2 max. or lower");
@@ -771,19 +784,42 @@ SK_POE2_PlugInCfg (void)
 
     if ( ImGui::Checkbox   ("Reduce Worker Threads", &spoof) )
     {
-      config.render.framerate.override_num_cpus =
-        ( spoof ? si.dwNumberOfProcessors : -1 );
+      config.priority.cpu_spoof_enable = spoof;
+
+      if (spoof)
+      {
+        if (config.priority.cpu_spoof_logical <= 0)
+          config.priority.cpu_spoof_logical =
+            suggested_processors;
+
+        if (config.priority.cpu_spoof_physical <= 0)
+          config.priority.cpu_spoof_physical =
+            std::max (1, config.priority.cpu_spoof_logical / 2);
+      }
     }
 
     if (spoof)
     {
-      ImGui::SameLine  (                                             );
-      ImGui::SliderInt ( "Number of Worker Threads",
-                        &config.render.framerate.override_num_cpus,
-                        1, si.dwNumberOfProcessors              );
+      config.priority.cpu_spoof_logical =
+        std::clamp ( config.priority.cpu_spoof_logical,
+          1, max_spoofed_processors );
+
+      config.priority.cpu_spoof_physical =
+        std::clamp ( config.priority.cpu_spoof_physical,
+          1, config.priority.cpu_spoof_logical );
+
+      ImGui::SliderInt ( "Logical Processors",
+                        &config.priority.cpu_spoof_logical,
+                        1, max_spoofed_processors );
+
+      ImGui::SliderInt ( "Physical Cores",
+                        &config.priority.cpu_spoof_physical,
+                        1, config.priority.cpu_spoof_logical );
     }
 
-    if (config.render.framerate.override_num_cpus != orig)
+    if ( config.priority.cpu_spoof_enable  != orig_spoof  ||
+         config.priority.cpu_spoof_logical != orig_logical ||
+         config.priority.cpu_spoof_physical != orig_physical )
     {
       ImGui::PushStyleColor (ImGuiCol_Text, (ImVec4&&)ImColor::HSV (.3f, .8f, .9f));
       ImGui::BulletText     ("Game Restart Required");

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -52,6 +52,12 @@ SK_LazyGlobal <concurrency::concurrent_unordered_set <DWORD>>                   
 
 void __make_self_titled (DWORD dwTid);
 
+void
+SK_CPU_Spoof_OnThreadNameObserved ( DWORD          dwTid,
+                                    const wchar_t* name,
+                                    const wchar_t* source,
+                                    LPVOID         caller );
+
 // Game has given this thread a custom name, it's special :)
 bool
 SK_Thread_HasCustomName (DWORD dwTid) noexcept
@@ -119,6 +125,13 @@ SK_Thread_QueryNameFromOS (DWORD dwTid)
         {
           auto name =
             _SK_ThreadNames.get()[dwTid].data();
+
+          SK_CPU_Spoof_OnThreadNameObserved (
+            dwTid,
+            wszThreadName,
+            L"GetThreadDescription",
+            _ReturnAddress ()
+          );
 
           __make_self_titled (dwTid);
           wcsncpy_s (name, SK_MAX_THREAD_NAME_LEN, wszThreadName, _TRUNCATE);
@@ -422,6 +435,25 @@ WINAPI
 SetThreadDescription_Detour (HANDLE hThread, PCWSTR lpThreadDescription)
 {
   SK_LOG_FIRST_CALL
+
+  if ( config.priority.cpu_spoof_enable                       &&
+       lpThreadDescription != nullptr                         &&
+       SK_ValidatePointer ((void *)lpThreadDescription, true) &&
+       StrStrIW (lpThreadDescription, L"Worker") != nullptr )
+  {
+    static volatile LONG worker_name_logs = 0;
+
+    if (InterlockedIncrement (&worker_name_logs) <= 128)
+    {
+      SK_LOGi0 (
+        L"CPU topology spoof: worker thread named => tid=0x%04x, handle=%p, desc=\"%ws\" [caller=%ws]",
+        GetThreadId (hThread),
+        hThread,
+        lpThreadDescription,
+        SK_SummarizeCaller (_ReturnAddress ()).c_str ()
+      );
+    }
+  }
 
   // Only do this if we have a hook on RaiseException
   extern RaiseException_pfn

--- a/src/widgets/cpu_widget.cpp
+++ b/src/widgets/cpu_widget.cpp
@@ -1720,27 +1720,75 @@ public:
       static SYSTEM_INFO             sinfo = { };
       SK_RunOnce (SK_GetSystemInfo (&sinfo));
 
+      constexpr DWORD max_cpu_records =
+        static_cast <DWORD> (_countof (cpu_stats.cpus) - 1);
+
+      DWORD pwi_count =
+        std::min <DWORD> (
+          std::max <DWORD> ( 1UL,
+            std::max <DWORD> (sinfo.dwNumberOfProcessors, cpu_stats.num_cpus)
+          ),
+          max_cpu_records
+        );
+
+      const DWORD active_processors =
+        GetActiveProcessorCount (ALL_PROCESSOR_GROUPS);
+
+      if (active_processors > 0)
+      {
+        pwi_count =
+          std::min <DWORD> (
+            std::max <DWORD> (pwi_count, active_processors),
+            max_cpu_records
+          );
+      }
+
+      auto alloc_power_info =
+        [&](DWORD count) -> PPROCESSOR_POWER_INFORMATION
+        {
+          return reinterpret_cast <PPROCESSOR_POWER_INFORMATION> (
+            pTLS != nullptr ?
+            pTLS->scratch_memory->cpu_info.alloc (
+              sizeof (PROCESSOR_POWER_INFORMATION) * count )
+                            : nullptr                     );
+        };
+
       PPROCESSOR_POWER_INFORMATION pwi =
-        reinterpret_cast <PPROCESSOR_POWER_INFORMATION> (
-          pTLS != nullptr ?
-          pTLS->scratch_memory->cpu_info.alloc (
-            sizeof (PROCESSOR_POWER_INFORMATION) * sinfo.dwNumberOfProcessors )
-                          : nullptr                     );
+        alloc_power_info (pwi_count);
 
       if (pwi == nullptr) return; // Ohnoes, I No Can Haz RAM (!!)
+
+      bool pwi_valid = false;
 
       static bool bUseNtPower = true;
       if (        bUseNtPower)
       {
-        const NTSTATUS ntStatus =
+        NTSTATUS ntStatus =
           CallNtPowerInformation ( ProcessorInformation,
-                                   nullptr, 0,
-                                   pwi,     sizeof (PROCESSOR_POWER_INFORMATION) * sinfo.dwNumberOfProcessors );
+                                    nullptr, 0,
+                                    pwi,     sizeof (PROCESSOR_POWER_INFORMATION) * pwi_count );
 
-        bUseNtPower =
+        if (ntStatus == STATUS_BUFFER_TOO_SMALL && pwi_count < max_cpu_records)
+        {
+          pwi_count = max_cpu_records;
+          pwi       = alloc_power_info (pwi_count);
+
+          if (pwi == nullptr)
+            return;
+
+          ntStatus =
+            CallNtPowerInformation ( ProcessorInformation,
+                                      nullptr, 0,
+                                      pwi,     sizeof (PROCESSOR_POWER_INFORMATION) * pwi_count );
+        }
+
+        pwi_valid =
           NT_SUCCESS (ntStatus);
 
-        if (! bUseNtPower)
+        bUseNtPower =
+          pwi_valid;
+
+        if (! pwi_valid)
         {
           SK_LOG0 ( ( L"Disabling CallNtPowerInformation (...) due to failed result: %x", ntStatus ),
                       L"CPUMonitor" );
@@ -1750,19 +1798,44 @@ public:
       if (   cpu_records.size () < ( static_cast <size_t> (cpu_stats.num_cpus) + 1 )
          ) { cpu_records.resize    ( static_cast <size_t> (cpu_stats.num_cpus) + 1 ); }
 
-      for (unsigned int i = 1; i < cpu_stats.num_cpus + 1 ; i++)
+      const DWORD sample_count =
+        std::min <DWORD> (cpu_stats.num_cpus, max_cpu_records);
+
+      if (pwi_valid)
       {
-        auto& stat_cpu =
-          cpu_stats.cpus [pwi [i-1].Number];
+        const DWORD pwi_sample_count =
+          std::min <DWORD> (sample_count, pwi_count);
 
-        cpu_records [i].addValue (
-          stat_cpu.getPercentLoad ()
-        );
+        for (DWORD i = 1; i < pwi_sample_count + 1 ; i++)
+        {
+          const DWORD cpu_number =
+            pwi [i-1].Number;
 
-        stat_cpu.CurrentMhz =
-          pwi [i-1].CurrentMhz;
-        stat_cpu.MaximumMhz =
-          pwi [i-1].MaxMhz;
+          if (cpu_number >= max_cpu_records)
+            continue;
+
+          auto& stat_cpu =
+            cpu_stats.cpus [cpu_number];
+
+          cpu_records [i].addValue (
+            stat_cpu.getPercentLoad ()
+          );
+
+          stat_cpu.CurrentMhz =
+            pwi [i-1].CurrentMhz;
+          stat_cpu.MaximumMhz =
+            pwi [i-1].MaxMhz;
+        }
+      }
+
+      else
+      {
+        for (DWORD i = 1; i < sample_count + 1 ; i++)
+        {
+          cpu_records [i].addValue (
+            cpu_stats.cpus [i-1].getPercentLoad ()
+          );
+        }
       }
 
       cpu_records [0].addValue (


### PR DESCRIPTION
## Summary

- Add per-profile `[Scheduler.CPUSpoof]` settings for enabled state, logical processors, and physical cores.
- Spoof common CPU topology entry points including `GetLogicalProcessorInformation(Ex)`, `GetSystemInfo`, active/max processor counts, process affinity, threadpool limits, and MSVCP hardware concurrency.
- Install the topology spoof path early and patch loaded-module imports / `GetProcAddress` / `LoadLibrary*` so games that query CPU topology during startup can see the configured topology.
- Add control-panel UI for `Spoof CPU Topology` plus optional Windows AppCompat `ProcessorCountLie` SDB install/uninstall helpers.
- Add worker-thread diagnostics and CPU monitor/widget bounds checks for spoofed topology scenarios.

## Paired SKIF PR

Launcher support is in SpecialKO/SKIF#56. That paired change forwards CPU-topology-enabled launches through SKIF's suspended early-injection path and makes config reset remove generated CPU topology SDB artifacts.

## Validation

- `$env:CL='/wd4828'; msbuild SpecialK.sln /m /p:Configuration=Release /p:Platform=x64 /p:VCToolsVersion=14.44.35207 /v:minimal`
- `git diff --cached --check`

`/wd4828` was needed only to get past an existing NVAPI header codepage warning that VS18 otherwise treats as fatal before compiling the changed files.