### PR TITLE
Make MGSV work again.

### DIFF
--- a/src/render/dxgi/dxgi_swapchain.cpp
+++ b/src/render/dxgi/dxgi_swapchain.cpp
@@ -774,9 +774,9 @@ IWrapDXGISwapChain::GetBuffer (UINT Buffer, REFIID riid, void **ppSurface)
              texDesc.Width  == swapDesc.BufferDesc.Width  &&
              texDesc.Height == swapDesc.BufferDesc.Height &&
              DirectX::MakeTypeless (            texDesc.Format) ==
-             DirectX::MakeTypeless (swapDesc.BufferDesc.Format) && !rb.active_traits.bOriginallysRGB )
-             //std::exchange (flip_model.last_srgb_mode, config.render.dxgi.srgb_behavior) ==
-             //                                          config.render.dxgi.srgb_behavior )
+             DirectX::MakeTypeless (swapDesc.BufferDesc.Format) &&
+             std::exchange (flip_model.last_srgb_mode, config.render.dxgi.srgb_behavior) ==
+                                                       config.render.dxgi.srgb_behavior )
       {
         return
           _backbuffers [Buffer]->QueryInterface (riid, ppSurface);


### PR DESCRIPTION
This broke with commmit https://github.com/SpecialKO/SpecialK/commit/5979b21c94cc9167fdc2272155c9ddcb9be472ab and caused MGSV to render a black screen with it's flip model upgrades active.

This reverts *only* the change that broke MGSV, might need more testing with other SRGB games?

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/0ae989f2-931a-454d-9a41-477624c41380" />
