### PR TITLE
Fix unused force_high_res_timers config variable

### DIFF
--- a/src/framerate.cpp
+++ b/src/framerate.cpp
@@ -415,7 +415,9 @@ CreateWaitableTimerW_Detour ( _In_opt_ LPSECURITY_ATTRIBUTES lpTimerAttributes,
   SK_LOG_FIRST_EXTERNAL_CALL
 
   static DWORD high_res_flag =
-    CREATE_WAITABLE_TIMER_HIGH_RESOLUTION;
+    config.render.framerate.force_high_res_timers
+    ? CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+    : 0x0;
 
   SK_RunOnce (sk::NVAPI::nvwgf2umx = // 32-bit and 64-bit versions
    (HMODULE)((uintptr_t)SK_GetModuleHandle (L"nvwgf2umx.dll") |
@@ -469,7 +471,9 @@ CreateWaitableTimerA_Detour ( _In_opt_ LPSECURITY_ATTRIBUTES lpTimerAttributes,
   SK_LOG_FIRST_EXTERNAL_CALL
 
   static DWORD high_res_flag =
-    CREATE_WAITABLE_TIMER_HIGH_RESOLUTION;
+    config.render.framerate.force_high_res_timers
+    ? CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+    : 0x0;
 
   SK_RunOnce (sk::NVAPI::nvwgf2umx = // 32-bit and 64-bit versions
    (HMODULE)((uintptr_t)SK_GetModuleHandle (L"nvwgf2umx.dll") |


### PR DESCRIPTION
The force_high_res_timers configuration variable was implemented and parsed from the INI file, but its value was never actually used in the waitable timer hooks.

As a result, timer promotion to high-resolution was running unconditionally, completely ignoring the user's preference.
This change binds the hook logic to the actual configuration flag, allowing users to disable the feature when needed.