### PR TITLE
Expose OSD font size to config/UI and improve OSD scaling logic

### DIFF
--- a/include/SpecialK/config.h
+++ b/include/SpecialK/config.h
@@ -305,6 +305,8 @@ struct sk_config_t
     int    red            = MAXDWORD32;
     int    green          = MAXDWORD32;
     int    blue           = MAXDWORD32;
+    float  font_size      =  18.0F;
+    float  init_font_size =  18.0F;
     float  scale          =  1.0F;
     int    pos_x          =  0;
     int    pos_y          =  0;

--- a/include/imgui/imgui_user.inl
+++ b/include/imgui/imgui_user.inl
@@ -196,8 +196,12 @@ SK_ImGui_LoadFonts (void)
     font_cfg           = {   };
     font_cfg.MergeMode = false;
 
+    float fs = std::max(1.0f, std::min(300.0f, config.osd.font_size)); //sanitization
+
     __SK_ImGui_FontConsolas =
-      LoadFont ("Consolab.ttf", 18, SK_ImGui_GetGlyphRangesDefaultEx (), &font_cfg);
+      LoadFont ("Consolab.ttf", fs, SK_ImGui_GetGlyphRangesDefaultEx (), &font_cfg);
+
+    config.osd.init_font_size = config.osd.font_size;
 
     InterlockedIncrementRelease (&init);
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -661,6 +661,7 @@ struct {
   } text;
 
   struct {
+    sk::ParameterFloat*   font_size               = nullptr;
     sk::ParameterFloat*   scale                   = nullptr;
     sk::ParameterInt*     pos_x                   = nullptr;
     sk::ParameterInt*     pos_y                   = nullptr;
@@ -1756,6 +1757,7 @@ auto DeclKeybind =
     ConfigEntry (osd.viewport.pos_x,                     L"OSD Position (X)",                                          osd_ini,         L"SpecialK.OSD",          L"PositionX"),
     ConfigEntry (osd.viewport.pos_y,                     L"OSD Position (Y)",                                          osd_ini,         L"SpecialK.OSD",          L"PositionY"),
 
+    ConfigEntry (osd.viewport.font_size,                 L"OSD Font Size",                                             osd_ini,         L"SpecialK.OSD",          L"FontSize"),
     ConfigEntry (osd.viewport.scale,                     L"OSD Scale",                                                 osd_ini,         L"SpecialK.OSD",          L"Scale"),
 
     ConfigEntry (osd.state.remember,                     L"Remember status monitoring state",                          osd_ini,         L"SpecialK.OSD",          L"RememberMonitoringState"),
@@ -6430,9 +6432,10 @@ auto DeclKeybind =
   osd.text.green->load     (config.osd.green);
   osd.text.blue->load      (config.osd.blue);
 
-  osd.viewport.pos_x->load (config.osd.pos_x);
-  osd.viewport.pos_y->load (config.osd.pos_y);
-  osd.viewport.scale->load (config.osd.scale);
+  osd.viewport.pos_x->load     (config.osd.pos_x);
+  osd.viewport.pos_y->load     (config.osd.pos_y);
+  osd.viewport.font_size->load (config.osd.font_size);
+  osd.viewport.scale->load     (config.osd.scale);
 
 
   silent->load              (config.system.silent);
@@ -7075,6 +7078,7 @@ SK_SaveConfig ( std::wstring name,
   osd.text.blue->store                        (config.osd.blue);
   osd.viewport.pos_x->store                   (config.osd.pos_x);
   osd.viewport.pos_y->store                   (config.osd.pos_y);
+  osd.viewport.font_size->store               (config.osd.font_size);
   osd.viewport.scale->store                   (config.osd.scale);
   osd.state.remember->store                   (config.osd.remember_state);
 

--- a/src/control_panel.cpp
+++ b/src/control_panel.cpp
@@ -5754,6 +5754,10 @@ static constexpr uint32_t UPLAY_OVERLAY_PS_CRC32C  { 0x35ae281c };
         //   and values out of range for this can be catastrophic.
         config.imgui.scale = SK_ImGui::SanitizeFontGlobalScale (config.imgui.scale);
         io.FontGlobalScale = config.imgui.scale;
+        auto OSD_font = SK_ImGui_GetFont_Consolas();
+
+        // Exclude OSD scale from this
+        OSD_font->Scale = 1.0F / config.imgui.scale;
       }
       ImGui::SetItemTooltip  ("Optimal UI layout requires 1.0; other scales "
                               "may not display as intended." );

--- a/src/control_panel/cfg_osd.cpp
+++ b/src/control_panel/cfg_osd.cpp
@@ -338,6 +338,16 @@ SK::ControlPanel::OSD::Draw (void)
              color [2] <= default_b + 0.001F    ) config.osd.blue  = (int)MAXDWORD;
       }
 
+      if (ImGui::SliderFloat("OSD Font Size", &config.osd.font_size, 10.0F, 100.0F))
+      {
+
+      }
+
+      ImGui::SetItemTooltip(
+        "Requires a Game Restart.\r\n\r\n"
+        " * High Font Size might cause problems in D3D9 games."
+      );
+
       if (ImGui::SliderFloat ("OSD Scale", &config.osd.scale, 0.5F, 10.0F))
       {
         SK_SetOSDScale (config.osd.scale, false, nullptr);

--- a/src/osd/text.cpp
+++ b/src/osd/text.cpp
@@ -2026,8 +2026,11 @@ SK_TextOverlay::update (const char* szText)
 
   ImGui::PushFont (pFont);
 
+  // Config's Font Size won't visually affect size of OSD.
+  // OSD size regulated by Scale
+  // With Scale 1.0 visually equal to Font Size 18.0 
   auto pImGuiWindow = ImGui::GetCurrentWindow ();
-       pImGuiWindow->FontWindowScale = font_.scale;
+  pImGuiWindow->FontWindowScale = font_.scale / (config.osd.init_font_size / 18);
 
         float baseline = 0.0f;
   const float spacing  = pImGuiWindow->CalcFontSize () + ImGui::GetStyle ().ItemSpacing.y;


### PR DESCRIPTION
- Exposed OSD font size to the INI configuration file.
- Added an OSD font size slider to the Control Panel.
- Separated font size from visual scale to prevent OSD layout shifting (font size changes text sharpness, while the visual size is only regulated by OSD Scale).
- Separated OSD scaling from the Control Panel UI scale (changing UI scale does not affect OSD size anymore).